### PR TITLE
Default s3 authentication

### DIFF
--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -110,9 +110,13 @@ class S3(StoreInterface):
 
     def fs(self, refresh: bool = False) -> s3fs.S3FileSystem:
         """
-        Get an `s3fs.S3FileSystem` object by logging in with the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables (which ideally should
-        be set beforehand in the ~/.aws/credentials file). By default, the filesystem is only created once, the first time this function is called. To force it create a
-        new one, set `refresh` to `True`.
+        Get an `s3fs.S3FileSystem` object. No authentication is performed on this step. Authentication will be performed when according to the rules
+        at https://s3fs.readthedocs.io/en/latest/#credentials when accessing the data.
+
+        By default, the filesystem is only created once, the first time this function is called. To force it create a new one, set `refresh`
+        to `True`.
+
+        no authentication will be performed yet. 
 
         Parameters
         ----------
@@ -125,16 +129,8 @@ class S3(StoreInterface):
             A filesystem object for interfacing with S3
         """
         if refresh or not hasattr(self, "_fs"):
-            try:
-                self._fs = s3fs.S3FileSystem(
-                    key=os.environ["AWS_ACCESS_KEY_ID"],
-                    secret=os.environ["AWS_SECRET_ACCESS_KEY"]
-                    )
-            # KeyError indicates credentials have not been manually specified
-            except KeyError:
-                # credentials automatically supplied from ~/.aws/credentials
-                self._fs = s3fs.S3FileSystem()
-            self.dm.info("Connected to S3 filesystem")
+            self._fs = s3fs.S3FileSystem()
+            self.dm.info("Initialized S3 filesystem. Credentials will be looked up according to rules at https://s3fs.readthedocs.io/en/latest/#credentials")
         return self._fs
 
     @property

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -110,7 +110,7 @@ class S3(StoreInterface):
 
     def fs(self, refresh: bool = False) -> s3fs.S3FileSystem:
         """
-        Get an `s3fs.S3FileSystem` object. No authentication is performed on this step. Authentication will be performed when according to the rules
+        Get an `s3fs.S3FileSystem` object. No authentication is performed on this step. Authentication will be performed according to the rules
         at https://s3fs.readthedocs.io/en/latest/#credentials when accessing the data.
 
         By default, the filesystem is only created once, the first time this function is called. To force it create a new one, set `refresh`

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -116,8 +116,6 @@ class S3(StoreInterface):
         By default, the filesystem is only created once, the first time this function is called. To force it create a new one, set `refresh`
         to `True`.
 
-        no authentication will be performed yet. 
-
         Parameters
         ----------
         refresh : bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gridded_etl_tools"
-version = "0.3.4"
+version = "0.3.4b"
 authors = [
     { name = "Robert Banick", email = "robert.banick@arbol.io" },
     { name = "Evan Schechter", email = "evan@arbol.io" },


### PR DESCRIPTION
s3fs will check for environment variables automatically, so we can just initialize S3FileSystem using default initialization and let the library handle authentication. Clarified the docs and logs to indicate that authentication is not performed at initialization.