### PR TITLE
make thread count a factor of RAM size

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     numpy
     p_tqdm
     pandas
+    psutil
     requests
     s3fs
     shapely


### PR DESCRIPTION
Non-urgent proposed improvement to the calculation of number of threads to use. Currently it is a factor of the number of CPUs, but this would make it a factor of RAM. Comes with some unit tests which test the following ratios.

```
INFO     <chirps_final_25> Using 24 threads on a 32-core system with 256.00GB RAM
INFO     <chirps_final_25> Using 12 threads on a 32-core system with 128.00GB RAM
INFO     <chirps_final_25> Using 16 threads on a 16-core system with 256.00GB RAM
INFO     <chirps_final_25> Using 1 threads on a 8-core system with 8.00GB RAM
INFO     <chirps_final_25> Using 1 threads on a 1-core system with 32.00GB RAM
```