### PR TITLE
add thread name to log statements

### DIFF
--- a/gridded_etl_tools/utils/logging.py
+++ b/gridded_etl_tools/utils/logging.py
@@ -15,7 +15,7 @@ class Logging(Attributes):
         cls,
         path: str = None,
         level: str = logging.INFO,
-        log_format: str = "%(asctime)s %(levelname)-8s <%(name)s> %(message)s",
+        log_format: str = "%(asctime)s <%(name)s in %(threadName)s> %(levelname)-8s %(message)s",
         time_format: str = "%Y/%m/%d %H:%M",
     ) -> logging.Handler:
         """
@@ -92,7 +92,7 @@ class Logging(Attributes):
     def log_to_console(
         cls,
         level: str = logging.INFO,
-        log_format: str = "%(levelname)-8s <%(name)s> %(message)s",
+        log_format: str = "%(levelname)-8s <%(name)s in %(threadName)s> %(message)s",
     ):
         """
         Attach a logging.StreamHandler that will write log statements at `level` or higher to the console. Since this attaches the stream handler


### PR DESCRIPTION
Minor update to logging to add the thread name to the log statement, which should make multithreaded logging clearer. After reviewing our logging code, it actually seems to be working more correctly than I thought, and we will have to look into Prefect's logging system to get multithreaded logging working there. But this will help with identifying logging issues in addition to making the logs more detailed.