### PR TITLE
Forecasts

### DIFF
--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -55,6 +55,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         s3_bucket_name=None,
         allow_overwrite=False,
         ipfs_host="http://127.0.0.1:5001",
+        forecast: bool = True,
         debug: bool = False,
         *args,
         **kwargs,
@@ -100,6 +101,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         self.custom_input_path = custom_input_path
         self.rebuild_requested = rebuild_requested
         self.debug = debug
+        self.forecast = forecast
 
         # Create a store object based on the passed store string. If `None`, treat as "local". If any string other than "local", "ipld", or "s3" is
         # passed, raise a `ValueError`.

--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -56,7 +56,6 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         allow_overwrite=False,
         ipfs_host="http://127.0.0.1:5001",
         forecast: bool = False,
-        debug: bool = False,
         *args,
         **kwargs,
     ):
@@ -100,7 +99,6 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         self.custom_latest_hash = custom_latest_hash
         self.custom_input_path = custom_input_path
         self.rebuild_requested = rebuild_requested
-        self.debug = debug
         self.forecast = forecast
 
         # Create a store object based on the passed store string. If `None`, treat as "local". If any string other than "local", "ipld", or "s3" is

--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -55,7 +55,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         s3_bucket_name=None,
         allow_overwrite=False,
         ipfs_host="http://127.0.0.1:5001",
-        forecast: bool = True,
+        forecast: bool = False,
         debug: bool = False,
         *args,
         **kwargs,

--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -55,6 +55,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         s3_bucket_name=None,
         allow_overwrite=False,
         ipfs_host="http://127.0.0.1:5001",
+        debug: bool = False,
         *args,
         **kwargs,
     ):
@@ -98,6 +99,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         self.custom_latest_hash = custom_latest_hash
         self.custom_input_path = custom_input_path
         self.rebuild_requested = rebuild_requested
+        self.debug = debug
 
         # Create a store object based on the passed store string. If `None`, treat as "local". If any string other than "local", "ipld", or "s3" is
         # passed, raise a `ValueError`.

--- a/gridded_etl_tools/utils/convenience.py
+++ b/gridded_etl_tools/utils/convenience.py
@@ -321,16 +321,21 @@ class Convenience(Attributes):
             A tuple defining the start and end date of a file's time dimension
 
         """
+        # use forecast times if they exist
+        if "forecast_reference_time" in dataset:
+            time_dim = "forecast_reference_time"
+        else:
+            time_dim = "time"
         # if there is only one date, set start and end to the same value
-        if dataset["time"].size == 1:
-            value = dataset["time"].values
+        if dataset[time_dim].size == 1:
+            value = dataset[time_dim].values
             if isinstance(value, np.ndarray):
                 value = value[0]
             start = self.numpydate_to_py(value)
             end = start
         else:
-            start = self.numpydate_to_py(dataset["time"][0].values)
-            end = self.numpydate_to_py(dataset["time"][-1].values)
+            start = self.numpydate_to_py(dataset[time_dim][0].values)
+            end = self.numpydate_to_py(dataset[time_dim][-1].values)
         return start, end
 
     def get_date_range_from_file(

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -260,8 +260,8 @@ class Metadata(Convenience, IPFS):
             stac_coll["extent"]["spatial"]["bbox"] = [[minx, miny, maxx, maxy]]
             stac_coll["extent"]["temporal"]["interval"] = [
                 [
-                    self.numpydate_to_py(dataset.time.values.min()).isoformat() + "Z",
-                    self.numpydate_to_py(dataset.time.values.max()).isoformat() + "Z",
+                    self.numpydate_to_py(dataset[self.time_dim].values.min()).isoformat() + "Z",
+                    self.numpydate_to_py(dataset[self.time_dim].values.max()).isoformat() + "Z",
                 ]
             ]
             # Create an href corresponding to the collection in order to note this in the collection and root catalog.
@@ -333,14 +333,16 @@ class Metadata(Convenience, IPFS):
         properties_dict["array_size"] = {
             "latitude": dataset.latitude.size,
             "longitude": dataset.longitude.size,
-            "time": dataset.time.size,
+            self.time_dim : dataset[self.time_dim].size,
         }
+        if self.time_dim == 'forecast_reference_time':
+            properties_dict["array_size"].update({"forecast_offset" : dataset.forecast_offset.size})
         # Set up date items in STAC-compliant style
         properties_dict["start_datetime"] = (
-            self.numpydate_to_py(dataset.time.values[0]).isoformat() + "Z"
+            self.numpydate_to_py(dataset[self.time_dim].values[0]).isoformat() + "Z"
         )
         properties_dict["end_datetime"] = (
-            self.numpydate_to_py(dataset.time.values[-1]).isoformat() + "Z"
+            self.numpydate_to_py(dataset[self.time_dim].values[-1]).isoformat() + "Z"
         )
         properties_dict["updated"] = (
             datetime.datetime.utcnow()
@@ -532,8 +534,8 @@ class Metadata(Convenience, IPFS):
         # Update time interval
         stac_coll["extent"]["temporal"]["interval"] = [
             [
-                self.numpydate_to_py(dataset.time.values.min()).isoformat() + "Z",
-                self.numpydate_to_py(dataset.time.values.max()).isoformat() + "Z",
+                self.numpydate_to_py(dataset[self.time_dim].values.min()).isoformat() + "Z",
+                self.numpydate_to_py(dataset[self.time_dim].values.max()).isoformat() + "Z",
             ]
         ]
         # Publish STAC Collection with updated fields

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -658,21 +658,6 @@ class Metadata(Convenience, IPFS):
                     "calendar": "gregorian",
                 }
             )
-            if "units" not in dataset.time.encoding.keys():
-                # reformat the dataset_start_date datetime to a CF compliant string if it exists....
-                if hasattr(self, "dataset_start_date"):
-                    dataset.time.encoding.update(
-                        {
-                            "units": f"days since {self.dataset_start_date.isoformat().replace('T00:00:00', ' 0:0:0 0')}",
-                        }
-                    )
-                # otherwise use None to indicate this is unknown at present
-                else:
-                    dataset.time.encoding.update(
-                        {
-                            "units": None,
-                        }
-                    )
         elif "forecast_reference_time" in dataset:
             dataset.forecast_reference_time.encoding.update(
                 {
@@ -681,21 +666,21 @@ class Metadata(Convenience, IPFS):
                     "calendar": "proleptic_gregorian",
                 }
             )
-            # if hasattr(self, "dataset_start_date"):
-            #     import ipdb; ipdb.set_trace(context=4)
-            #     dataset.forecast_reference_time.encoding.update(
-            #         {
-            #             "units": f"days since {self.dataset_start_date.isoformat().replace('T00:00:00', ' 0:0:0 0')}",
-            #         }
-            #     )
-            #     import ipdb; ipdb.set_trace(context=4)
-            # # otherwise use existing units
-            # else:
-            #     dataset.forecast_reference_time.encoding.update(
-            #         {
-            #             "units": f"days since {dataset.forecast_reference_time.encoding['units'].replace('T00:00:00', ' 0:0:0 0')}",
-            #         }
-            #     )
+        if "units" not in dataset[self.time_dim].encoding.keys():
+            # reformat the dataset_start_date datetime to a CF compliant string if it exists....
+            if hasattr(self, "dataset_start_date"):
+                dataset[self.time_dim].encoding.update(
+                    {
+                        "units": f"days since {self.dataset_start_date.isoformat().replace('T00:00:00', ' 0:0:0 0')}",
+                    }
+                )
+            # otherwise use None to indicate this is unknown at present
+            else:
+                dataset[self.time_dim].encoding.update(
+                    {
+                        "units": None,
+                    }
+                )
         return dataset
 
     def merge_in_outside_metadata(self, dataset: xr.Dataset) -> xr.Dataset:

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -336,7 +336,7 @@ class Metadata(Convenience, IPFS):
             self.time_dim : dataset[self.time_dim].size,
         }
         if self.time_dim == 'forecast_reference_time':
-            properties_dict["array_size"].update({"forecast_offset" : dataset.forecast_offset.size})
+            properties_dict["array_size"].update({"step" : dataset.step.size})
         # Set up date items in STAC-compliant style
         properties_dict["start_datetime"] = (
             self.numpydate_to_py(dataset[self.time_dim].values[0]).isoformat() + "Z"

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -651,28 +651,51 @@ class Metadata(Convenience, IPFS):
             }
         )
         # Encode 'time' dimension with the Climate and Forecast Convention standards used by major climate data providers.
-        dataset.time.encoding.update(
-            {
-                "long_name": "time",
-                "calendar": "gregorian",
-            }
-        )
-        if "units" not in dataset.time.encoding.keys():
-            # reformat the dataset_start_date datetime to a CF compliant string if it exists....
-            if hasattr(self, "dataset_start_date"):
-                dataset.time.encoding.update(
-                    {
-                        "units": f"days since {self.dataset_start_date.isoformat().replace('T00:00:00', ' 0:0:0 0')}",
-                    }
-                )
-            # otherwise use None to indicate this is unknown at present
-            else:
-                dataset.time.encoding.update(
-                    {
-                        "units": None,
-                    }
-                )
-
+        if "time" in dataset:
+            dataset.time.encoding.update(
+                {
+                    "long_name": "time",
+                    "calendar": "gregorian",
+                }
+            )
+            if "units" not in dataset.time.encoding.keys():
+                # reformat the dataset_start_date datetime to a CF compliant string if it exists....
+                if hasattr(self, "dataset_start_date"):
+                    dataset.time.encoding.update(
+                        {
+                            "units": f"days since {self.dataset_start_date.isoformat().replace('T00:00:00', ' 0:0:0 0')}",
+                        }
+                    )
+                # otherwise use None to indicate this is unknown at present
+                else:
+                    dataset.time.encoding.update(
+                        {
+                            "units": None,
+                        }
+                    )
+        elif "forecast_reference_time" in dataset:
+            dataset.forecast_reference_time.encoding.update(
+                {
+                    "long_name": "initial time of forecast",
+                    "standard_name" : "forecast_reference_time",
+                    "calendar": "proleptic_gregorian",
+                }
+            )
+            # if hasattr(self, "dataset_start_date"):
+            #     import ipdb; ipdb.set_trace(context=4)
+            #     dataset.forecast_reference_time.encoding.update(
+            #         {
+            #             "units": f"days since {self.dataset_start_date.isoformat().replace('T00:00:00', ' 0:0:0 0')}",
+            #         }
+            #     )
+            #     import ipdb; ipdb.set_trace(context=4)
+            # # otherwise use existing units
+            # else:
+            #     dataset.forecast_reference_time.encoding.update(
+            #         {
+            #             "units": f"days since {dataset.forecast_reference_time.encoding['units'].replace('T00:00:00', ' 0:0:0 0')}",
+            #         }
+            #     )
         return dataset
 
     def merge_in_outside_metadata(self, dataset: xr.Dataset) -> xr.Dataset:

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -452,6 +452,7 @@ class Publish(Creation, Metadata):
         if not hasattr(self, "metadata"):
             # This will occur when user is only updating metadata and has not parsed
             self.populate_metadata()
+            self.set_key_dims()
 
         # This will do nothing if catalog already exists
         self.create_root_stac_catalog()

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -769,7 +769,6 @@ class Publish(Creation, Metadata):
         originaL_chunks : dict
             The dimension:size parameters for the original dataset
         """
-        original_dataset = xr.open_zarr(self.mapper(), chunks=None)
         append_dataset = self.prep_update_dataset(
             update_dataset, append_times, original_chunks
         )
@@ -779,13 +778,6 @@ class Publish(Creation, Metadata):
         append_dataset.attrs["update_is_append_only"] = True
         self.info("Indicating the dataset is appending data only.")
         self.to_zarr(append_dataset, mapper, consolidated=True, append_dim=self.time_dim)
-
-        # If you are backdating data, the time dimension must be sorted or the newly appended records will return at the end of the time dim.
-        if max(append_dataset[self.time_dim]).values <= min(original_dataset[self.time_dim]).values:
-            updated_dataset = self.store.dataset()
-            updated_dataset = updated_dataset.sortby(self.time_dim)
-            import ipdb; ipdb.set_trace(context=4)
-            self.to_zarr(updated_dataset, mapper, consolidated=True, mode='a')
 
         self.info(
             f"Appended records for {len(append_dataset[self.time_dim].values)} datetimes to original zarr"

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -599,7 +599,7 @@ class Publish(Creation, Metadata):
             self.standard_dims = ["time", "latitude", "longitude"]
             self.time_dim = "time"
         else:
-            self.standard_dims = ["forecast_reference_time", "constant_offset", "latitude", "longitude"]
+            self.standard_dims = ["forecast_reference_time", "forecast_offset", "latitude", "longitude"]
             self.time_dim = "forecast_reference_time"
 
     # UPDATES

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -1,4 +1,3 @@
-import os
 import datetime
 import multiprocessing
 import time
@@ -7,11 +6,9 @@ import re
 import fsspec
 import pprint
 import dask
-import subprocess
 import pathlib
 import glob
 import itertools
-import s3fs
 
 import pandas as pd
 import numpy as np

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -600,7 +600,7 @@ class Publish(Creation, Metadata):
             self.standard_dims = ["time", "latitude", "longitude"]
             self.time_dim = "time"
         else:
-            self.standard_dims = ["forecast_reference_time", "forecast_offset", "latitude", "longitude"]
+            self.standard_dims = ["forecast_reference_time", "step", "latitude", "longitude"]
             self.time_dim = "forecast_reference_time"
 
     # UPDATES

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -744,7 +744,7 @@ class Publish(Creation, Metadata):
             insert_dataset.attrs["update_is_append_only"] = False
             self.info("Indicating the dataset is not appending data only.")
             self.to_zarr(
-                insert_slice.drop(self.standard_dims[:-1]),
+                insert_slice.drop(self.standard_dims[1:]),
                 mapper,
                 region={self.time_dim: slice(region[0], region[1])},
             )

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -869,21 +869,21 @@ class Publish(Creation, Metadata):
         for date_pair in datetime_ranges:
             if not self.forecast:
                 start_int = list(original_dataset[self.time_dim].values).index(
-                    original_dataset.sel(time=date_pair[0], method="nearest").time
+                    original_dataset.sel(time=date_pair[0], method="nearest")[self.time_dim]
                 )
                 end_int = (
                     list(original_dataset[self.time_dim].values).index(
-                        original_dataset.sel(time=date_pair[1], method="nearest").time
+                        original_dataset.sel(time=date_pair[1], method="nearest")[self.time_dim]
                     )
                     + 1
                 )
             elif self.forecast:
                 start_int = list(original_dataset[self.time_dim].values).index(
-                    original_dataset.sel(forecast_reference_time=date_pair[0], method="nearest").time
+                    original_dataset.sel(forecast_reference_time=date_pair[0], method="nearest")[self.time_dim]
                 )
                 end_int = (
                     list(original_dataset[self.time_dim].values).index(
-                        original_dataset.sel(forecast_reference_time=date_pair[1], method="nearest").time
+                        original_dataset.sel(forecast_reference_time=date_pair[1], method="nearest")[self.time_dim]
                     )
                     + 1
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gridded_etl_tools"
-version = "0.3.4b"
+version = "0.3.5"
 authors = [
     { name = "Robert Banick", email = "robert.banick@arbol.io" },
     { name = "Evan Schechter", email = "evan@arbol.io" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gridded_etl_tools"
-version = "0.3.5"
+version = "0.4.0"
 authors = [
     { name = "Robert Banick", email = "robert.banick@arbol.io" },
     { name = "Evan Schechter", email = "evan@arbol.io" },

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     dask[array,diagnostics,distributed]==2023.1.1
     fsspec
     ipldstore @ git+https://github.com/dClimate/ipldstore@v2.1.0
-    kerchunk @ git+https://github.com/dClimate/kerchunk
+    kerchunk
     multiformats
     natsort
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ keywords = Climate, Zarr, ETL, IPFS
 packages = find:
 python_requires = >=3.10
 install_requires =
+    cfgrib
     dag-cbor==0.2.2
     dask[array,diagnostics,distributed]==2023.1.1
     fsspec


### PR DESCRIPTION
Opening a PR to accommodate 4-Dimensional forecast datasets within the `tools` library. 

This PR modifies core Zarr parsing and metadata methods to
* Read and convert GRIBs and NetCDFs held on S3 Buckets to Kerchunk JSON objects without downloading them
* Do the above implicitly within the `extract`, rather than `transform`, step of an ETL
* Read and convert local GRIBs similarly
* Implement standard naming conventions for forecast datasets vs. 3D datasets

Additionally, the PR adds functionalities to
* Trigger debugging-specific methods or operations
* Upgrade Kerchunk to latest version and rewire existing methods to play nicely with its expanded capabilities