### PR TITLE
rewiring zarr_json_path to export w/in datasets

### DIFF
--- a/gridded_etl_tools/utils/convenience.py
+++ b/gridded_etl_tools/utils/convenience.py
@@ -47,7 +47,7 @@ class Convenience(Attributes):
         pathlib.Path
             The path to the local final Zarr JSON file
         """
-        return self.local_input_root() / "merged_zarr_jsons" / f"{self.name()}_zarr.json"
+        return self.local_input_root / "merged_zarr_jsons" / f"{self.name()}_zarr.json"
 
     @classmethod
     def json_key(cls, append_date: bool = False) -> str:

--- a/gridded_etl_tools/utils/convenience.py
+++ b/gridded_etl_tools/utils/convenience.py
@@ -40,14 +40,14 @@ class Convenience(Attributes):
 
     def zarr_json_path(self) -> pathlib.Path:
         """
-        A path to the virtual Zarr
+        A path to the local final Zarr
 
         Returns
         -------
         pathlib.Path
-            The path to the virtual Zarr JSON file
+            The path to the local final Zarr JSON file
         """
-        return self.root_directory() / f"{self.name()}_zarr.json"
+        return self.local_input_root() / "merged_zarr_jsons" / f"{self.name()}_zarr.json"
 
     @classmethod
     def json_key(cls, append_date: bool = False) -> str:

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -91,10 +91,15 @@ class Creation(Convenience):
         ----------
         file_path : str
             A file path to an input GRIB or NetCDF-4 Classic file. Can be local or on a remote S3 bucket that accepts anonymous access.
-        scan_indices : int, slice(int,int)
+        scan_indices : int, slice(int)
             One or many indices to filter the JSONS returned by `scan_grib` when scanning remotely.
             When multiple options are returned that usually means the provider prepares this data variable at multiple depth / surface layers.
             We currently default to the 1st (index=0), as we tend to use the shallowest depth / surface layer in ETLs we've written.
+
+        Returns
+        -------
+        scanned_zarr_json : dict
+            A JSON representation of a local/remote NetCDF or GRIB file produced by Kerchunk and readable by Xarray as a lazy Dataset.
 
         """
         if not file_path.lower().startswith('s3://'):

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -116,7 +116,7 @@ class Creation(Convenience):
                 }
             if self.file_type == 'NetCDF':
                 with self.store.fs().open(file_path, **s3_so) as infile:
-                    scanned_zarr_json = SingleHdf5ToZarr(h5f=infile, url=file_path)
+                    scanned_zarr_json = SingleHdf5ToZarr(h5f=infile, url=file_path).translate()
             elif 'GRIB' in self.file_type:
                 scanned_zarr_json = scan_grib(url=file_path, storage_options= s3_so, filter = self.grib_filter, inline_threshold=20)[scan_indices]
             # append/extend to self.zarr_jsons for later use in an ETL's `transform` step

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -34,7 +34,7 @@ class Creation(Convenience):
 
     # KERCHUNKING
 
-    def create_zarr_json(self, force_overwrite: bool = False):
+    def create_zarr_json(self, use_existing: bool = False):
         """
         Convert list of local input files (MultiZarr) to a single JSON representing a "virtual" Zarr
 
@@ -46,13 +46,14 @@ class Creation(Convenience):
 
         Parameters
         ----------
-        force_overwrite : bool, optional
-            Switch to create (or not) a new JSON at `DatasetManager.zarr_json_path()` even if the path exists
+        use_existing : bool, optional
+            Switch to use (or not) an existing MultiZarr JSON at `DatasetManager.zarr_json_path()`.
+            Defaults to ovewriting any existing JSON under the assumption new data has been found.
 
         """
         self.zarr_json_path().parent.mkdir(mode=0o755, exist_ok=True)
         # Generate a multizarr if it doesn't exist. If one exists, use that.
-        if not self.zarr_json_path().exists() or force_overwrite:
+        if not self.zarr_json_path().exists() or not use_existing:
             start_kerchunking = time.time()
             # Prepapre a list of zarr_jsons and feed that to MultiZarrtoZarr
             if not hasattr(self, "zarr_jsons"):

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -116,7 +116,7 @@ class Creation(Convenience):
                 }
             if self.file_type == 'NetCDF':
                 with self.store.fs().open(file_path, **s3_so) as infile:
-                    scanned_zarr_json = SingleHdf5ToZarr(h5f=infile, url=file_path).translate()
+                    scanned_zarr_json = SingleHdf5ToZarr(h5f=infile, url=file_path)
             elif 'GRIB' in self.file_type:
                 scanned_zarr_json = scan_grib(url=file_path, storage_options= s3_so, filter = self.grib_filter, inline_threshold=20)[scan_indices]
             # append/extend to self.zarr_jsons for later use in an ETL's `transform` step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gridded_etl_tools"
-version = "0.4.6"
+version = "0.4.7"
 authors = [
     { name = "Robert Banick", email = "robert.banick@arbol.io" },
     { name = "Evan Schechter", email = "evan@arbol.io" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gridded_etl_tools"
-version = "0.4.2"
+version = "0.4.6"
 authors = [
     { name = "Robert Banick", email = "robert.banick@arbol.io" },
     { name = "Evan Schechter", email = "evan@arbol.io" },


### PR DESCRIPTION
Finding the merged MultiZarr for ETLs run on a remote server is tricky as it gets buried in the root directory, which can be a surprisingly ambiguous location on containerized systems. I’d prefer to consolidate its placement alongside downloaded files for ease of reference.