### PR TITLE
chore: ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dask-worker-space/
 
 # Editor/IDE
 *.swp
+.vscode
 
 # Tests temp data
 tests/local_*/


### PR DESCRIPTION
Ignore the directory VSCode uses for workspace config.