### PR TITLE
feat: enable compression for all stores

### DIFF
--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -62,6 +62,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         use_local_zarr_jsons: bool = False,
         skip_prepare_input_files: bool = False,
         encryption_key: str = None,
+        use_compression: bool = True,
         *args,
         **kwargs,
     ):
@@ -104,6 +105,8 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
             If provided, data will be encrypted using `encryption_key` with
             XChaCha20Poly1305. Use :func:`.encryption.generate_encryption_key` to
             generate a random encryption key to be passed in here.
+        use_compression: bool, optional
+            Data in this dataset will be compressed unless this is set to `False`.
         """
         # call IPFS init
         super().__init__(host=ipfs_host)
@@ -177,6 +180,8 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         self.info(f"Using {self.dask_num_threads} threads on a {multiprocessing.cpu_count()}-core system with {total_memory_gb:.2f}GB RAM")
 
         self.encryption_key = register_encryption_key(encryption_key) if encryption_key else None
+
+        self.use_compression = use_compression
 
     # SETUP
 

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -801,11 +801,7 @@ class Metadata(Convenience, IPFS):
             The dataset being published, after metadata update
 
         """
-        # Leave compression off for IPLD
-        if isinstance(self.store, IPLD):
-            compressor = None
-        else:
-            compressor = numcodecs.Blosc()
+        compressor = numcodecs.Blosc()
 
         for coord in ["latitude", "longitude"]:
             dataset[coord].attrs.pop("chunks", None)

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -801,7 +801,7 @@ class Metadata(Convenience, IPFS):
             The dataset being published, after metadata update
 
         """
-        compressor = numcodecs.Blosc()
+        compressor = numcodecs.Blosc() if self.use_compression else None
 
         for coord in ["latitude", "longitude"]:
             dataset[coord].attrs.pop("chunks", None)

--- a/tests/utils/test_metadata.py
+++ b/tests/utils/test_metadata.py
@@ -1,7 +1,10 @@
 from unittest import mock
 
+import numcodecs
+
 from gridded_etl_tools import dataset_manager
 from gridded_etl_tools.utils import encryption
+from gridded_etl_tools.utils import store
 
 
 def unimplemented(*args, **kwargs):
@@ -73,3 +76,11 @@ class TestMetadata:
         assert len(filters) == 2
         assert filters[0] == "SomeOtherFilter"
         assert isinstance(filters[1], encryption.EncryptionFilter)
+
+    def test_remove_unwanted_fields_w_ipld_store(self):
+        dataset = mock.MagicMock()
+        dataset["data"].encoding = {}
+        md = DummyManager()
+        md.store = store.IPLD(md)
+        dataset = md.remove_unwanted_fields(dataset)
+        assert isinstance(dataset["data"].encoding["compressor"], numcodecs.Blosc)

--- a/tests/utils/test_metadata.py
+++ b/tests/utils/test_metadata.py
@@ -84,3 +84,11 @@ class TestMetadata:
         md.store = store.IPLD(md)
         dataset = md.remove_unwanted_fields(dataset)
         assert isinstance(dataset["data"].encoding["compressor"], numcodecs.Blosc)
+
+    def test_remove_unwanted_fields_w_ipld_store_no_compression(self):
+        dataset = mock.MagicMock()
+        dataset["data"].encoding = {}
+        md = DummyManager(use_compression=False)
+        md.store = store.IPLD(md)
+        dataset = md.remove_unwanted_fields(dataset)
+        assert dataset["data"].encoding["compressor"] is None


### PR DESCRIPTION
Based on real world experimentation, I'm recommending we use compression for all data stores.

To get some real world numbers, I first wrote a [script to write 10 years worth of CHIRPS data to a Zarr](https://gist.github.com/chrisrossi/f44d8416a4ef802209df901ba575535d). I ran it once without compression and then ran it again with compression, so I'd have two datasets to compare. I then ran a [script to calculate space saving from IPLD deduplication](https://gist.github.com/chrisrossi/ce5eb9a3d65d01c406cd44286c0b74e5) on each dataset.

```
(zarr) chris@spirit:~/proj/arbol/gridded-etl-tools$ python analyze_duplicates.py `cat uncompressed_cid`
IPFS Deduplication has saved 847,384,732/5,300,734,082 bytes (15.99%)
(zarr) chris@spirit:~/proj/arbol/gridded-etl-tools$ python analyze_duplicates.py `cat compressed_cid`
IPFS Deduplication has saved 18,488,975/1,265,650,096 bytes (1.46%)
```

The results are, then: 

| Data | Size |
| ---------------- | --------------- |
| Without compression or deduplication | 5,300,734,082 (5.30G) |
| Without compression, with deduplication from IPLD |  4,453,349,350 (4.45G) |
| With compression (and a little deduplication from IPLD) | 1,247,161,121 (1.25G) |

In this sample, at least, compression saves a lot more disk space than IPLD deduplication, so there's no need to refrain from compressing in the hopes that IPLD deduplication will be more helpful. I have no reason to think the results will be vastly different with a different dataset, but we can certainly try some more if we want to gather more data.