### PR TITLE
test: test coverage for utils.attributes

### DIFF
--- a/examples/managers/chirps.py
+++ b/examples/managers/chirps.py
@@ -85,22 +85,16 @@ class CHIRPS(DatasetManager):
     def host_organization(cls) -> str:
         return "My Organization"
 
-    @classmethod
-    def name(cls) -> str:
-        return "chirps"
+    dataset_name = "chirps"
 
     def relative_path(self) -> str:
         return super().relative_path() / "chirps"
 
-    @classmethod
-    def collection(cls) -> str:
-        """Overall collection of data. Used for filling and referencing STAC Catalog."""
-        return "CHIRPS"
+    collection_name = "CHIRPS"
+    """Overall collection of data. Used for filling and referencing STAC Catalog."""
 
-    @classmethod
-    def temporal_resolution(cls) -> str:
-        """Increment size along the "time" coordinate axis"""
-        return cls.SPAN_DAILY
+    time_resolution = DatasetManager.SPAN_DAILY
+    """Increment size along the "time" coordinate axis"""
 
     @classmethod
     def data_var(self) -> str:
@@ -153,29 +147,23 @@ class CHIRPS(DatasetManager):
         """
         return "NetCDF"
 
-    @classmethod
-    def remote_protocol(cls) -> str:
-        """
-        Remote protocol string for MultiZarrToZarr and Xarray to use when opening input files. 'File' for local, 's3'
-        for S3, etc. See fsspec docs for more details.
-        """
-        return "file"
+    protocol = "file"
+    """
+    Remote protocol string for MultiZarrToZarr and Xarray to use when opening input files. 'File' for local, 's3'
+    for S3, etc. See fsspec docs for more details.
+    """
 
-    @classmethod
-    def identical_dims(cls) -> list[str]:
-        """
-        List of dimension(s) whose values are identical in all input datasets. This saves Kerchunk time by having it
-        read these dimensions only one time, from the first input file
-        """
-        return ["latitude", "longitude"]
+    identical_dimensions = ["latitude", "longitude"]
+    """
+    List of dimension(s) whose values are identical in all input datasets. This saves Kerchunk time by having it
+    read these dimensions only one time, from the first input file
+    """
 
-    @classmethod
-    def concat_dims(cls) -> list[str]:
-        """
-        List of dimension(s) by which to concatenate input files' data variable(s) -- usually time, possibly with some
-        other relevant dimension
-        """
-        return ["time"]
+    concat_dimensions = ["time"]
+    """
+    List of dimension(s) by which to concatenate input files' data variable(s) -- usually time, possibly with some
+    other relevant dimension
+    """
 
     @property
     def bbox_rounding_value(self) -> int:
@@ -331,10 +319,7 @@ class CHIRPSFinal(CHIRPS):
     A class for finalized CHIRPS data
     """
 
-    @classmethod
-    def name(cls) -> str:
-        """Name used to refer to the dataset where it's published"""
-        return f"{super().name()}_final"
+    dataset_name = f"{CHIRPS.dataset_name}_final"
 
     def relative_path(self) -> pathlib.Path:
         return super().relative_path() / "final"
@@ -353,10 +338,7 @@ class CHIRPSFinal05(CHIRPSFinal):
     Finalized CHIRPS data at 0.05 resolution
     """
 
-    @classmethod
-    def name(cls) -> str:
-        """Name used to refer to the dataset where it's published"""
-        return f"{super().name()}_05"
+    dataset_name = f"{CHIRPSFinal.dataset_name}_05"
 
     def relative_path(self) -> pathlib.Path:
         """Relative path used to store data under 'datasets' and 'climate' folders"""
@@ -391,10 +373,7 @@ class CHIRPSFinal25(CHIRPSFinal):
         kwargs.update(chunks)
         super().__init__(*args, **kwargs)
 
-    @classmethod
-    def name(cls) -> str:
-        """Name used to refer to the dataset where it's published"""
-        return f"{super().name()}_25"
+    dataset_name = f"{CHIRPSFinal.dataset_name}_25"
 
     def relative_path(self) -> pathlib.Path:
         """Relative path used to store data under 'datasets' and 'climate' folders"""
@@ -416,10 +395,7 @@ class CHIRPSPrelim05(CHIRPS):
     Preliminary CHIRPS data at 0.05 resolution
     """
 
-    @classmethod
-    def name(cls) -> str:
-        """Name used to refer to the dataset where it's published"""
-        return f"{super().name()}_prelim_05"
+    dataset_name = f"{CHIRPS.dataset_name}_prelim_05"
 
     def relative_path(self) -> pathlib.Path:
         """Relative path used to store data under 'datasets' and 'climate' folders"""

--- a/examples/managers/chirps.py
+++ b/examples/managers/chirps.py
@@ -45,7 +45,7 @@ class CHIRPS(DatasetManager):
         static_metadata = {
             "coordinate reference system": "EPSG:4326",
             "update cadence": self.update_cadence,
-            "temporal resolution": self.temporal_resolution(),
+            "temporal resolution": self.time_resolution,
             "spatial resolution": self.spatial_resolution,
             "spatial precision": 0.00001,
             "provider url": "http://chg.geog.ucsb.edu/",
@@ -70,9 +70,9 @@ class CHIRPS(DatasetManager):
             "terms of service": "To the extent possible under the law, Pete Peterson has waived all copyright and "
             "related or neighboring rights to CHIRPS. CHIRPS data is in the public domain as registered with "
             "Creative Commons.",
-            "name": self.name(),
+            "name": self.dataset_name,
             "updated": str(datetime.datetime.now()),
-            "missing value": self.missing_value_indicator(),
+            "missing value": self.missing_value,
             "tags": self.tags,
             "standard name": self.standard_name,
             "long name": self.long_name,
@@ -126,13 +126,11 @@ class CHIRPS(DatasetManager):
         """First date in dataset. Used to populate corresponding encoding and metadata."""
         return datetime.datetime(1981, 1, 1, 0)
 
-    @classmethod
-    def missing_value_indicator(cls) -> int:
-        """
-        Value within the source data that should be automatically converted to 'nan' by Xarray.
-        Cannot be empty/None or Kerchunk will fail, so use -9999 if no NoData value actually exists in the dataset.
-        """
-        return -9999
+    missing_value = -9999
+    """
+    Value within the source data that should be automatically converted to 'nan' by Xarray.
+    Cannot be empty/None or Kerchunk will fail, so use -9999 if no NoData value actually exists in the dataset.
+    """
 
     @property
     def dataset_download_url(self) -> str:
@@ -281,7 +279,7 @@ class CHIRPS(DatasetManager):
         """
         dataset = super().remove_unwanted_fields(dataset)
         for variable in dataset.variables:
-            dataset[variable].encoding["_FillValue"] = self.missing_value_indicator()
+            dataset[variable].encoding["_FillValue"] = self.missing_value
         # Remove extraneous data from the data variable's attributes
         keys_to_remove = [
             "Conventions",

--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -225,7 +225,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
         str
             The name of the dataset
         """
-        return self.name()
+        return self.dataset_name
 
     @deprecation.deprecated(details="Compare Dataset types directly")
     def __eq__(self, other: DatasetManager) -> bool:
@@ -238,7 +238,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
             If the other `DatasetManager` instance has the same name, return `True`
         """
         if isinstance(other, type(self)):
-            return self.name() == other.name()
+            return self.dataset_name == other.dataset_name
 
         return False
 
@@ -339,7 +339,7 @@ class DatasetManager(Logging, Publish, ABC, IPFS):
             A dataset source class
         """
         for source in cls.get_subclasses():
-            if source.name() == name:
+            if source.dataset_name == name:
                 return source
 
         warnings.warn(f"failed to set manager from name {name}, could not find corresponding class")

--- a/gridded_etl_tools/utils/attributes.py
+++ b/gridded_etl_tools/utils/attributes.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import typing
 import warnings
 
 import deprecation
@@ -83,217 +84,148 @@ class Attributes(ABC):
     def name(cls) -> str:
         return cls._find_fallback("dataset_name")
 
+    collection_name = abstract_class_property(fallback="collection")
+    """
+    Name of the collection
+    """
+
     @classmethod
-    @abstractmethod
+    @deprecation.deprecated("Use the collection_name attribute")
     def collection(cls):
-        """'
-        Placeholder class for collection name
-        """
+        return cls._find_fallback("collection_name")
 
-    @property
-    def file_type(cls):
-        """
-        Class method to populate with a string representing the file type of each child class (and edition if
-        relevant), e.g. GRIB1 for ERA5 data, GRIB2 for RTMA, or NetCDF for Copernicus Marine Service
+    file_type = None
+    """
+    The file type of each child class (and edition if relevant), e.g. GRIB1 for ERA5 data, GRIB2 for RTMA, or NetCDF
+    for Copernicus Marine Service
 
-        Used to trigger file format-appropriate functions and methods for Kerchunking and Xarray operations.
-        """
+    Used to trigger file format-appropriate functions and methods for Kerchunking and Xarray operations.
+    """
+
+    protocol: str = abstract_class_property(fallback="remote_protocol")
+    """
+    Remote protocol string for MultiZarrToZarr and Xarray to use when opening input files. 'File' for local, 's3'
+    for S3, etc. See fsspec docs for more details.
+    """
 
     @classmethod
-    @abstractmethod
+    @deprecation.deprecated("Use the protocol attribute")
     def remote_protocol(cls):
-        """
-        Remote protocol string for MultiZarrToZarr and Xarray to use when opening input files. 'File' for local, 's3'
-        for S3, etc. See fsspec docs for more details.
-        """
+        return cls._find_fallback("protocol")
+
+    identical_dimensions = abstract_class_property(fallback="identical_dims")
+    """
+    List of dimension(s) whose values are identical in all input datasets. This saves Kerchunk time by having it
+    read these dimensions only one time, from the first input file
+    """
 
     @classmethod
-    @abstractmethod
+    @deprecation.deprecated("Use the identical_dimensions attribute")
     def identical_dims(cls):
-        """
-        List of dimension(s) whose values are identical in all input datasets. This saves Kerchunk time by having it
-        read these dimensions only one time, from the first input file
-        """
+        return cls._find_fallback("identical_dimensions")
+
+    concat_dimensions = abstract_class_property(fallback="concat_dims")
+    """
+    List of dimension(s) by which to concatenate input files' data variable(s) -- usually time, possibly with some
+    other relevant dimension
+    """
 
     @classmethod
-    @abstractmethod
+    @deprecation.deprecated("Use the concat_dimensions attribute")
     def concat_dims(cls):
-        """
-        List of dimension(s) by which to concatenate input files' data variable(s) -- usually time, possibly with some
-        other relevant dimension
-        """
+        return cls._find_fallback("concat_dimensions")
 
-    @property
-    def data_var_dtype(self) -> str:
-        """
-        Property specifying the data type of the data variable
+    data_var_dtype: float = "<f4"
+    """
+    The data type of the data variable
+    """
 
-        Returns
-        -------
-        str
-            The final data type of the dataset's data variable
-        """
-        return "<f4"
+    spatial_resolution: typing.Optional[float] = None
+    """
+    The spatial resolution of a dataset in decimal degrees
+    """
 
-    def spatial_resolution(self) -> float:
-        """
-        Property specifying the spatial resolution of a dataset in decimal degrees
+    spatial_precision: typing.Optional[float] = None
+    """
+    The spatial resolution of a dataset in decimal degrees
+    """
 
-        Returns
-        -------
-        float
-            The spatial resolution of a dataset
-        """
-
-    def spatial_precision(self) -> float:
-        """
-        Property specifying the spatial resolution of a dataset in decimal degrees
-
-        Returns
-        -------
-        float
-            The spatial resolution of a dataset
-        """
+    time_resolution: str = abstract_class_property(fallback="temporal_resolution")
+    """
+    The time resolution of the dataset as a string (e.g. "hourly", "daily", "monthly", etc.)
+    """
 
     @classmethod
-    @abstractmethod
+    @deprecation.deprecated("Use the time_resolution attribute")
     def temporal_resolution(cls) -> str:
-        """
-        Returns the time resolution of the dataset as a string (e.g. "hourly", "daily", "monthly", etc.)
+        return cls._find_fallback("time_resolution")
 
-        Returns
-        -------
-        str
-           Temporal resolution of the dataset
+    update_cadence: typing.Optional[str] = None
+    """
+    The frequency with which a dataset is updated.
+    """
 
-        """
-
-    @classmethod
-    def update_cadence(self) -> str:
-        """
-        Property specifying the frequency with which a dataset is updated
-        Optional class method, may just be specified directly in the static metadata
-
-        Returns
-        -------
-        str
-            The update frequency of a dataset
-        """
+    missing_value: str = ""
+    """
+    Indicator of a missing value in a dataset
+    """
 
     @classmethod
+    @deprecation.deprecated("Use the missing_value attribute")
     def missing_value_indicator(cls) -> str:
-        """
-        Default indicator of a missing value in a dataset
+        return cls.missing_value
 
-        Returns
-        -------
-        str
-           Stand-in for a missing value
+    tags: list[str] == [""]
+    """
+    Tags for dataset.
+    """
 
-        """
-        return ""
+    forecast: bool = False
+    """
+    ``True`` if the dataset provides forecast data.
+    """
 
-    @property
-    def tags(cls) -> list[str]:
-        """
-        Default tag for a dataset. Prevents crashes on parse if no tags assigned.
+    ensemble: bool = False
+    """
+    ``True`` if the dataset provides ensemble data.
+    """
 
-        Returns
-        -------
-        list[str]
-           Stand-in for a dataset's tags
+    hindcast: bool = False
+    """
+    ``True`` if the dataset privides hindcast data.
+    """
 
-        """
-        return [""]
+    forecast_hours: list[int] = []
+    """"
+    Hours provided by the forecast, if any.
+    """
 
-    @property
-    def forecast(self) -> bool:
-        """Forecast defaults to False, must override for actual forecast datasets"""
-        return False
+    ensemble_numbers: list[int] = []
+    """
+    Numbers uses for ensemble, if any.
+    """
 
-    @property
-    def ensemble(self) -> bool:
-        """Ensemble defaults to False, must override for actual ensemble datasets"""
-        return False
+    hindcast_steps: list[int] = []
+    """
+    Steps used for hindcast, if any.
+    """
 
-    @property
-    def hindcast(self) -> bool:
-        """Hindcast defaults to False, must override for actual hindcast datasets"""
-        return False
-
-    @property
-    def forecast_hours(self) -> list[int]:
-        """To be overwritten by actual forecast datasets"""
-        return list(None)
-
-    @property
-    def ensemble_numbers(self) -> list[int]:
-        """To be overwritten by actual ensemble datasets"""
-        return list(None)
-
-    @property
-    def hindcast_steps(self) -> list[int]:
-        """To be overwritten by actual hindcast datasets"""
-        return list(None)
+    update_cadence_bounds: typing.Optional[tuple[np.timedelta64, np.timedelta64]] = None
+    """G
+    If a dataset doesn't update on a monotonic schedule return a tuple noting the lower and upper bounds of acceptable
+    updates. Intended to prevent time contiguity checks from short-circuiting valid updates for datasets with
+    non-monotic update schedules.
+    """
 
     @classmethod
-    def irregular_update_cadence(self) -> None | tuple[np.timedelta64, np.timedelta64]:
-        """
-        If a dataset doesn't update on a monotonic schedule return a tuple noting the lower and upper bounds of
-        acceptable updates Intended to prevent time contiguity checks from short-circuiting valid updates for datasets
-        with non-monotic update schedules
-        """
-        return None
+    @deprecation.deprecated("Use the update_cadence_bounds attribute")
+    def irregular_update_cadence(cls) -> None | tuple[np.timedelta64, np.timedelta64]:
+        return cls.update_cadence_bounds
 
-    @property
-    def bbox_rounding_value(self) -> int:
-        """
-        Value to round bbox values by. Specify within the dataset for very high resolution datasets
-        to prevent mismatches with rounding behavior of old Arbol API.
-
-        Returns
-        -------
-        int
-            The number of decimal places to round bounding box values to.
-        """
-        return 5
-
-    @property
-    def store(self) -> StoreInterface:
-        """
-        Get the store interface object for the store the output will be written to.
-
-        If it has not been previously set, a `etls.utils.store.Local` will be initialized and returned.
-
-        Returns
-        -------
-        StoreInterface
-            Object for interfacing with a Zarr's data store.
-        """
-        if not hasattr(self, "_store"):
-            self._store = Local(self)
-        return self._store
-
-    @store.setter
-    def store(self, value: StoreInterface):
-        """
-        Assign a `StoreInterface` to the store property. If the assigned value is not an instance of `StoreInterface`,
-        a `ValueError` will be raised.
-
-        Parameters
-        ----------
-        value
-            An instance of `StoreInterface`
-
-        Raises
-        ------
-        ValueError
-            Raised if anything other than a `StoreInterface` is passed.
-        """
-        if isinstance(value, StoreInterface):
-            self._store = value
-        else:
-            raise ValueError(f"Store must be an instance of {StoreInterface}")
+    bbox_rounding_value: int = 5
+    """
+    The number of decimal places to round bounding box values to.
+    """
 
 
 # Won't get called automatically, because Attributes isn't a subclass of itself

--- a/gridded_etl_tools/utils/attributes.py
+++ b/gridded_etl_tools/utils/attributes.py
@@ -1,11 +1,9 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 import typing
 import warnings
 
 import deprecation
 import numpy as np
-
-from .store import StoreInterface, Local
 
 _NO_FALLBACK = object()
 
@@ -175,7 +173,7 @@ class Attributes(ABC):
     def missing_value_indicator(cls) -> str:
         return cls.missing_value
 
-    tags: list[str] == [""]
+    tags: list[str] = [""]
     """
     Tags for dataset.
     """

--- a/gridded_etl_tools/utils/attributes.py
+++ b/gridded_etl_tools/utils/attributes.py
@@ -28,6 +28,14 @@ class abstract_class_property(property):
         raise TypeError(f"No value in {cls.__name__} for abstract class attribute {self.name}")
 
 
+class readonly_property:
+    def __init__(self, value):
+        self.value = value
+
+    def __get__(self, obj, cls):
+        return self.value
+
+
 class Attributes(ABC):
     """
     Abstract base class containing default attributes of Zarr ETLs
@@ -67,12 +75,15 @@ class Attributes(ABC):
 
         raise TypeError(f"No value in {cls.__name__} for abstract class attribute {attr}")
 
+    organization: str = readonly_property("")  # e.g. "Arbol"
+    """
+    Name of the organization (your organization) hosting the data being published. Used in STAC metadata.
+    """
+
     @classmethod
+    @deprecation.deprecated("Use the organization attribute")
     def host_organization(self) -> str:
-        """
-        Name of the organization (your organization) hosting the data being published. Used in STAC metadata.
-        """
-        return ""  # e.g. "Arbol"
+        return self.organization
 
     dataset_name = abstract_class_property(fallback="name")
     """

--- a/gridded_etl_tools/utils/attributes.py
+++ b/gridded_etl_tools/utils/attributes.py
@@ -19,7 +19,8 @@ class abstract_class_property(property):
             fallback = getattr(cls, self.fallback, None)
             if fallback is not None:
                 warnings.warn(
-                    f"{cls.__name__}.{self.fallback}() is deprecated. Use {cls.__name__}.{self.name}.",
+                    f"{cls.__name__} is using deprecated fallback, {self.fallback}, for {self.name}. "
+                    f"{cls.__name__} should define {self.name}.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -28,7 +29,7 @@ class abstract_class_property(property):
         raise TypeError(f"No value in {cls.__name__} for abstract class attribute {self.name}")
 
 
-class readonly_property:
+class readonly_property(property):
     def __init__(self, value):
         self.value = value
 
@@ -82,8 +83,8 @@ class Attributes(ABC):
 
     @classmethod
     @deprecation.deprecated("Use the organization attribute")
-    def host_organization(self) -> str:
-        return self.organization
+    def host_organization(cls) -> str:
+        return cls.organization
 
     dataset_name = abstract_class_property(fallback="name")
     """

--- a/gridded_etl_tools/utils/attributes.py
+++ b/gridded_etl_tools/utils/attributes.py
@@ -5,6 +5,8 @@ import warnings
 import deprecation
 import numpy as np
 
+from gridded_etl_tools.utils.store import StoreInterface
+
 _NO_FALLBACK = object()
 
 
@@ -209,7 +211,7 @@ class Attributes(ABC):
     """
 
     update_cadence_bounds: typing.Optional[tuple[np.timedelta64, np.timedelta64]] = None
-    """G
+    """
     If a dataset doesn't update on a monotonic schedule return a tuple noting the lower and upper bounds of acceptable
     updates. Intended to prevent time contiguity checks from short-circuiting valid updates for datasets with
     non-monotic update schedules.
@@ -224,6 +226,21 @@ class Attributes(ABC):
     """
     The number of decimal places to round bounding box values to.
     """
+
+    @property
+    def store(self) -> StoreInterface:
+        """
+        The store where output is written to.
+        """
+        # The constructor has called the setter, so we don't need to check for the presence of the attribute.
+        return self._store
+
+    @store.setter
+    def store(self, new_store):
+        if not isinstance(new_store, StoreInterface):
+            raise TypeError("Expected instance of StoreInterface, got {type(new_store)}")
+
+        self._store = new_store
 
 
 # Won't get called automatically, because Attributes isn't a subclass of itself

--- a/gridded_etl_tools/utils/logging.py
+++ b/gridded_etl_tools/utils/logging.py
@@ -171,7 +171,7 @@ class Logging(Attributes):
 
         """
         pathlib.Path.mkdir(pathlib.Path("./logs"), mode=0o777, parents=False, exist_ok=True)
-        return pathlib.Path("logs") / f"{cls.name()}_{logging.getLevelName(level)}.log"
+        return pathlib.Path("logs") / f"{cls.dataset_name}_{logging.getLevelName(level)}.log"
 
     @classmethod
     def log(cls, message: str, level: str = logging.INFO, **kwargs):
@@ -194,7 +194,7 @@ class Logging(Attributes):
             exception information. See the logging module for all keyword arguments.
 
         """
-        logging.getLogger(cls.name()).log(level, message, **kwargs)
+        logging.getLogger(cls.dataset_name).log(level, message, **kwargs)
 
     @classmethod
     def info(cls, message: str, **kwargs):

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -35,14 +35,14 @@ class Metadata(Convenience, IPFS):
         return {
             "stac_version": "1.0.0",
             "type": "Feature",
-            "id": cls.name(),
+            "id": cls.dataset_name,
             "collection": cls.collection(),
             "links": [],
             "assets": {
                 "zmetadata": {
-                    "title": cls.name(),
+                    "title": cls.dataset_name,
                     "type": "application/json",
-                    "description": f"Consolidated metadata file for {cls.name()} Zarr store, readable as a Zarr "
+                    "description": f"Consolidated metadata file for {cls.dataset_name} Zarr store, readable as a Zarr "
                     "dataset by Xarray",
                     "roles": ["metadata", "zarr-consolidated-metadata"],
                 }
@@ -453,7 +453,7 @@ class Metadata(Convenience, IPFS):
                 "rel": "self",
                 "href": str(href),
                 "type": "application/geo+json",
-                "title": f"{self.name()} metadata",
+                "title": f"{self.dataset_name} metadata",
             }
         )
         # push final STAC Item to backing store

--- a/gridded_etl_tools/utils/metadata.py
+++ b/gridded_etl_tools/utils/metadata.py
@@ -600,17 +600,17 @@ class Metadata(Convenience, IPFS):
         dataset.encoding = {
             self.data_var(): {
                 "dtype": self.data_var_dtype,
-                "_FillValue": self.missing_value_indicator(),
+                "_FillValue": self.missing_value,
                 # deprecated by NUG but maintained for backwards compatibility
-                "missing_value": self.missing_value_indicator(),
+                "missing_value": self.missing_value,
             }
         }
         dataset[self.data_var()].encoding.update(
             {
                 "units": self.unit_of_measurement,
-                "_FillValue": self.missing_value_indicator(),
+                "_FillValue": self.missing_value,
                 # deprecated by NUG but maintained for backwards compatibility
-                "missing_value": self.missing_value_indicator(),
+                "missing_value": self.missing_value,
                 "chunks": tuple(val for val in self.requested_zarr_chunks.values()),
                 "preferred_chunks": self.requested_zarr_chunks,
             }

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -284,10 +284,10 @@ class Transform(Convenience):
             Kwargs for kerchunk's MultiZarrToZarr method
         """
         opts = dict(
-            remote_protocol=cls.remote_protocol(),
+            remote_protocol=cls.protocol,
             remote_options={"anon": True},
-            identical_dims=cls.identical_dims(),
-            concat_dims=cls.concat_dims(),
+            identical_dims=cls.identical_dimensions,
+            concat_dims=cls.concat_dimensions,
             preprocess=cls.preprocess_kerchunk,
         )
         return opts
@@ -724,7 +724,7 @@ class Publish(Transform, Metadata):
             backend_kwargs={
                 "storage_options": {
                     "fo": zarr_json_path,
-                    "remote_protocol": self.remote_protocol(),
+                    "remote_protocol": self.protocol,
                     "skip_instance_cache": True,
                     "default_cache_type": "readahead",
                 },

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -320,7 +320,7 @@ class Transform(Convenience):
                 ref_names.add(re.match(file_match_pattern, ref).group(1))
         for ref in ref_names:
             fill_value_fix = json.loads(refs[f"{ref}/.zarray"])
-            fill_value_fix["fill_value"] = str(cls.missing_value_indicator())
+            fill_value_fix["fill_value"] = str(cls.missing_value)
             refs[f"{ref}/.zarray"] = json.dumps(fill_value_fix)
         return refs
 

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -1014,7 +1014,7 @@ class Publish(Transform, Metadata):
         """
         # NOTE this won't work for months (returns 1 minute), we could define a more precise method with if/else
         # statements if needed.
-        dataset_time_span = f"1{self.temporal_resolution()[0]}"
+        dataset_time_span = f"1{self.time_resolution[0]}"
         complete_time_series = pd.Series(update_dataset[self.time_dim].values)
         # Define datetime range starts as anything with > 1 unit diff with the previous value,
         # and ends as > 1 unit diff with the following. First/Last will return NAs we must fill.
@@ -1102,19 +1102,15 @@ class Publish(Transform, Metadata):
         previous_time = times[0]
         for instant in times[1:]:
             # Warn if not using expected delta
-            if self.irregular_update_cadence():
+            if self.update_cadence_bounds:
                 self.warn(
-                    f"Because dataset has irregular cadence {self.irregular_update_cadence()} expected delta "
+                    f"Because dataset has irregular cadence {self.update_cadence_bounds} expected delta "
                     f"{expected_delta} is not being used for checking time contiguity"
                 )
-                if (
-                    not self.irregular_update_cadence()[0]
-                    <= (instant - previous_time)
-                    <= self.irregular_update_cadence()[1]
-                ):
+                if not self.update_cadence_bounds[0] <= (instant - previous_time) <= self.update_cadence_bounds[1]:
                     self.warn(
                         f"Time value {instant} and previous time {previous_time} do not fit within anticipated update "
-                        f"cadence {self.irregular_update_cadence()}"
+                        f"cadence {self.update_cadence_bounds}"
                     )
                     return False
             elif instant - previous_time != expected_delta:

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ def unit(session):
 @nox.session(py=DEFAULT_INTERPRETER)
 def cover(session):
     session.install("coverage")
-    session.run("coverage", "report", "--fail-under=55", "--show-missing")
+    session.run("coverage", "report", "--fail-under=63", "--show-missing")
     session.run("coverage", "erase")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ def unit(session):
 @nox.session(py=DEFAULT_INTERPRETER)
 def cover(session):
     session.install("coverage")
-    session.run("coverage", "report", "--fail-under=63", "--show-missing")
+    session.run("coverage", "report", "--fail-under=60", "--show-missing")
     session.run("coverage", "erase")
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,5 @@
 import pathlib
 import shutil
-import numpy as np
 
 from gridded_etl_tools.dataset_manager import DatasetManager
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -126,14 +126,14 @@ original_json_key = DatasetManager.json_key
 
 
 def patched_json_key(self):
-    return f"{self.name()}-{self.temporal_resolution()}_test_initial"
+    return f"{self.dataset_name}-{self.temporal_resolution()}_test_initial"
 
 
 original_zarr_json_path = DatasetManager.zarr_json_path
 
 
 def patched_zarr_json_path(self):
-    return pathlib.Path(".") / f"{self.name()}_zarr.json"
+    return pathlib.Path(".") / f"{self.dataset_name}_zarr.json"
 
 
 original_root_stac_catalog = DatasetManager.default_root_stac_catalog

--- a/tests/common.py
+++ b/tests/common.py
@@ -150,7 +150,3 @@ def patched_root_stac_catalog(self):
             The catalogs and collections describe single providers. Each may contain one or multiple datasets. \
             Each individual dataset has been documented as STAC Items.",
     }
-
-
-def patched_irregular_update_cadence(self):
-    return [np.timedelta64(3, "D"), np.timedelta64(4, "D")]

--- a/tests/common.py
+++ b/tests/common.py
@@ -126,7 +126,7 @@ original_json_key = DatasetManager.json_key
 
 
 def patched_json_key(self):
-    return f"{self.dataset_name}-{self.temporal_resolution()}_test_initial"
+    return f"{self.dataset_name}-{self.time_resolution}_test_initial"
 
 
 original_zarr_json_path = DatasetManager.zarr_json_path

--- a/tests/system/test_chirps.py
+++ b/tests/system/test_chirps.py
@@ -118,7 +118,6 @@ def teardown_module(request, heads_path):
     request.addfinalizer(test_clean)
 
 
-@pytest.mark.order(1)
 def test_initial_dry_run(request, mocker, manager_class, heads_path, test_chunks, initial_input_path, root):
     """
     Test that a dry run parse of CHIRPS data does not, in fact, parse data.
@@ -142,7 +141,6 @@ def test_initial_dry_run(request, mocker, manager_class, heads_path, test_chunks
         manager.zarr_hash_to_dataset(manager.latest_hash())
 
 
-@pytest.mark.order(1)
 def test_initial(request, mocker, manager_class, heads_path, test_chunks, initial_input_path, root):
     """
     Test a parse of CHIRPS data. This function is run automatically by pytest because the function name starts with

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -58,11 +58,6 @@ def noop(*args, **kwargs):
 
 
 class DummyManagerBase(dataset_manager.DatasetManager):
-    collection = unimplemented
-    concat_dims = unimplemented
-    identical_dims = unimplemented
-    remote_protocol = unimplemented
-
     prepare_input_files = noop
 
     unit_of_measurement = "parsecs"
@@ -84,11 +79,6 @@ class DummyManagerBase(dataset_manager.DatasetManager):
     def data_var(self):
         return "data"
 
-    @classmethod
-    def temporal_resolution(cls) -> str:
-        """Increment size along the "time" coordinate axis"""
-        return cls.SPAN_DAILY
-
     def extract(self, date_range=None):
         return super().extract(date_range=date_range)
 
@@ -102,7 +92,12 @@ class DummyManagerBase(dataset_manager.DatasetManager):
 
 
 class DummyManager(DummyManagerBase):
+    concat_dimensions = ["z", "zz"]
     dataset_name = "DummyManager"
+    collection_name = "Vintage Guitars"
+    identical_dimensions = ["x", "y"]
+    protocol = "handshake"
+    time_resolution = dataset_manager.DatasetManager.SPAN_DAILY
 
 
 # Set up overcomplicated mro for testing get_subclass(es)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,6 +40,11 @@ def fake_complex_update_dataset():
 
 
 @pytest.fixture
+def base_class():
+    return DummyManagerBase
+
+
+@pytest.fixture
 def manager_class():
     return DummyManager
 
@@ -52,7 +57,7 @@ def noop(*args, **kwargs):
     """Do nothing"""
 
 
-class DummyManager(dataset_manager.DatasetManager):
+class DummyManagerBase(dataset_manager.DatasetManager):
     collection = unimplemented
     concat_dims = unimplemented
     identical_dims = unimplemented
@@ -65,10 +70,6 @@ class DummyManager(dataset_manager.DatasetManager):
     time_dim = "time"
     encryption_key = None
     fill_value = ""
-
-    @classmethod
-    def name(cls):
-        return cls.__name__
 
     def __init__(self, requested_dask_chunks=None, requested_zarr_chunks=None, *args, **kwargs):
         if requested_dask_chunks is None:
@@ -100,21 +101,25 @@ class DummyManager(dataset_manager.DatasetManager):
         return self._static_metadata
 
 
+class DummyManager(DummyManagerBase):
+    dataset_name = "DummyManager"
+
+
 # Set up overcomplicated mro for testing get_subclass(es)
 class John(DummyManager):
-    ...
+    dataset_name = "John"
 
 
 class Paul(DummyManager):
-    ...
+    dataset_name = "Paul"
 
 
 class George(John, Paul):
-    ...
+    dataset_name = "George"
 
 
 class Ringo(George):
-    ...
+    dataset_name = "Ringo"
 
 
 original_times = np.array(

--- a/tests/unit/test_zarr_methods.py
+++ b/tests/unit/test_zarr_methods.py
@@ -67,12 +67,13 @@ def test_preprocess_kerchunk(mocker, manager_class: DatasetManager, example_zarr
     Test that the preprocess_kerchunk method successfully changes the _FillValue attribute of all arrays
     """
     orig_fill_value = json.loads(example_zarr_json["refs"]["latitude/.zarray"])["fill_value"]
+
     # prepare a dataset manager and preprocess a Zarr JSON
-    dm = get_manager(manager_class)
-    mocker.patch(
-        "tests.unit.conftest.DummyManager.missing_value_indicator",
-        return_value=-8888,
-    )
+    class MyManagerClass(manager_class):
+        missing_value = -8888
+
+    dm = get_manager(MyManagerClass)
+
     pp_zarr_json = dm.preprocess_kerchunk(example_zarr_json["refs"])
     # populate before/after fill value variables
     modified_fill_value = int(json.loads(pp_zarr_json["latitude/.zarray"])["fill_value"])

--- a/tests/unit/test_zarr_methods.py
+++ b/tests/unit/test_zarr_methods.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 from gridded_etl_tools.dataset_manager import DatasetManager
-from ..common import get_manager, patched_irregular_update_cadence
+from ..common import get_manager
 
 
 def test_standard_dims(mocker, manager_class: DatasetManager):
@@ -110,7 +110,8 @@ def test_are_times_in_expected_order(mocker, manager_class: DatasetManager):
     assert not dm.are_times_in_expected_order(out_of_order, expected_delta=expected_delta)
     # Check that irregular cadences pass
     mocker.patch(
-        "gridded_etl_tools.utils.attributes.Attributes.irregular_update_cadence", patched_irregular_update_cadence
+        "gridded_etl_tools.utils.attributes.Attributes.update_cadence_bounds",
+        [np.timedelta64(3, "D"), np.timedelta64(4, "D")],
     )
     three_and_four_day_updates = [contig[0], contig[3], contig[6], contig[10]]
     assert dm.are_times_in_expected_order(three_and_four_day_updates, expected_delta=expected_delta)

--- a/tests/unit/utils/test_attributes.py
+++ b/tests/unit/utils/test_attributes.py
@@ -1,0 +1,89 @@
+import pytest
+
+from gridded_etl_tools.utils import attributes
+
+
+class TestAttributes:
+    @staticmethod
+    def test_abstract_class_attribute_access_missing_attribute(manager_class):
+        class Base(manager_class):
+            foo = attributes.abstract_class_property()
+
+        class Subclass(Base):
+            ...
+
+        with pytest.raises(TypeError):
+            Subclass.foo
+
+    @staticmethod
+    def test_abstract_class_attribute_construct_instance_missing_attribute(manager_class):
+        class Base(manager_class):
+            foo = attributes.abstract_class_property()
+
+        class Subclass(Base):
+            ...
+
+        with pytest.raises(TypeError):
+            Subclass()
+
+    @staticmethod
+    def test_abstract_class_attribute_with_fallback(manager_class):
+        class Base(manager_class):
+            foo = attributes.abstract_class_property(fallback="bar")
+
+        class Subclass(Base):
+            @classmethod
+            def bar(cls):
+                return "hi mom!"
+
+        with pytest.deprecated_call():
+            assert Subclass.foo == "hi mom!"
+
+    @staticmethod
+    def test_abstract_class_attribute_instance_with_fallback(manager_class):
+        class Base(manager_class):
+            foo = attributes.abstract_class_property(fallback="bar")
+
+        class Subclass(Base):
+            @classmethod
+            def bar(cls):
+                return "hi mom!"
+
+        with pytest.deprecated_call():
+            assert Subclass().foo == "hi mom!"
+
+    @staticmethod
+    def test_abstract_class_attribute_with_missing_fallback(manager_class):
+        class Base(manager_class):
+            foo = attributes.abstract_class_property(fallback="bar")
+
+        class Subclass(Base):
+            ...
+
+        with pytest.raises(TypeError):
+            Subclass.foo
+
+    @staticmethod
+    def test_host_organization(manager_class):
+        assert manager_class.host_organization() == ""
+
+    @staticmethod
+    def test_dataset_name_fallback_to_name(base_class):
+        class Subclass(base_class):
+            @classmethod
+            def name(cls):
+                return "SubclassName"
+
+        with pytest.deprecated_call():
+            assert Subclass.dataset_name == "SubclassName"
+
+    @staticmethod
+    def test_name(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.name() == "DummyManager"
+
+    @staticmethod
+    def test_name_no_fallback(base_class):
+        with pytest.deprecated_call():
+            with pytest.raises(TypeError):
+                base_class.name()

--- a/tests/unit/utils/test_attributes.py
+++ b/tests/unit/utils/test_attributes.py
@@ -64,6 +64,36 @@ class TestAttributes:
             Subclass.foo
 
     @staticmethod
+    def test_backwards_compatible_no_fallback_or_override(manager_class):
+        class MyClass(manager_class):
+            foo = attributes._backwards_compatible("bar", "get_foo")
+
+        assert MyClass.foo == "bar"
+
+    @staticmethod
+    def test_backwards_compatible_w_attribute_override(manager_class):
+        class Base(manager_class):
+            foo = attributes._backwards_compatible("bar", "get_foo")
+
+        class Subclass(Base):
+            foo = "baz"
+
+        assert Subclass.foo == "baz"
+
+    @staticmethod
+    def test_backwards_compatible_w_class_fallback_override(manager_class):
+        class Base(manager_class):
+            foo = attributes._backwards_compatible("bar", "get_foo")
+
+        class Subclass(Base):
+            @classmethod
+            def get_foo(self):
+                return "boo"
+
+        with pytest.deprecated_call():
+            assert Subclass.foo == "boo"
+
+    @staticmethod
     def test_host_organization(manager_class):
         with pytest.deprecated_call():
             assert manager_class.host_organization() == ""

--- a/tests/unit/utils/test_attributes.py
+++ b/tests/unit/utils/test_attributes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gridded_etl_tools.utils import attributes, store
+from gridded_etl_tools.utils import attributes
 
 
 class TestAttributes:

--- a/tests/unit/utils/test_attributes.py
+++ b/tests/unit/utils/test_attributes.py
@@ -65,7 +65,14 @@ class TestAttributes:
 
     @staticmethod
     def test_host_organization(manager_class):
-        assert manager_class.host_organization() == ""
+        with pytest.deprecated_call():
+            assert manager_class.host_organization() == ""
+
+    @staticmethod
+    def test_organization_read_only(manager_class):
+        dm = manager_class()
+        with pytest.raises(AttributeError):
+            dm.organization = "Hydra"
 
     @staticmethod
     def test_dataset_name_fallback_to_name(base_class):

--- a/tests/unit/utils/test_attributes.py
+++ b/tests/unit/utils/test_attributes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gridded_etl_tools.utils import attributes
+from gridded_etl_tools.utils import attributes, store
 
 
 class TestAttributes:
@@ -87,3 +87,38 @@ class TestAttributes:
         with pytest.deprecated_call():
             with pytest.raises(TypeError):
                 base_class.name()
+
+    @staticmethod
+    def test_collection(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.collection() == "Vintage Guitars"
+
+    @staticmethod
+    def test_remote_protocol(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.remote_protocol() == "handshake"
+
+    @staticmethod
+    def test_identical_dims(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.identical_dims() == ["x", "y"]
+
+    @staticmethod
+    def test_concat_dims(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.concat_dims() == ["z", "zz"]
+
+    @staticmethod
+    def test_temporal_resolution(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.temporal_resolution() == "daily"
+
+    @staticmethod
+    def test_missing_value_indicator(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.missing_value_indicator() == ""
+
+    @staticmethod
+    def test_irregular_update_cadence(manager_class):
+        with pytest.deprecated_call():
+            assert manager_class.irregular_update_cadence() is None

--- a/tests/unit/utils/test_attributes.py
+++ b/tests/unit/utils/test_attributes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gridded_etl_tools.utils import attributes
+from gridded_etl_tools.utils import attributes, store
 
 
 class TestAttributes:
@@ -122,3 +122,17 @@ class TestAttributes:
     def test_irregular_update_cadence(manager_class):
         with pytest.deprecated_call():
             assert manager_class.irregular_update_cadence() is None
+
+    @staticmethod
+    def test_store_with_correct_type(manager_class):
+        dm = manager_class()
+        local_store = store.Local(dm)
+        dm.store = local_store
+        assert dm.store is local_store
+        assert dm.store.dm is dm
+
+    @staticmethod
+    def test_store_with_incorrect_type(manager_class):
+        dm = manager_class()
+        with pytest.raises(TypeError):
+            dm.store = "not a store"


### PR DESCRIPTION
This initial commit is primarily to show a strategy for converting abstract class attributes accessed by method calls to use simple attribute access instead. It turned out to be a little more involved than I'd hoped, mostly due to the requirement of preserving backwards compatibility. ("We do these things, not because they are easy, but because we thought they would be easy.")

This commit uses the ``name`` attribute as the first example for a working strategy going forward.

The primary innovation here is the introduction of the ``abstract_class_property`` class that is used to define abstract class properties. This is implemented independently of the ``abc`` package in the standard library, since it has no support for abstract class attributes.  One thing that's a little weird is figuring out when to check for concrete values for abstract attributes. With instance methods and attributes, the ``abc`` package just waits until instantiation to check the entire class to make sure it's concrete before instantiating. We do that, too, for these class properties, but since a class property can be accessed independtly of an instance, we also check individual properties as they are accessed. Some mechanisms for checking subclasses as they are declared were tried and discarded, as there's no real good way to know when the user has finished subclassing an abstract base class, unless they try to instantiate it.

As far as backwards compatibility, the first difficulty is we can't simply convert calls to ``DatasetManager.name()`` to ``DatasetManager.name``, since that would break downstream code that still uses the method call syntax. Unfortunately, that means that for each attribute we want to convert we need to introduce a new name. In this case ``name`` has been migrated to ``dataset_name``. Code which uses the ``name`` class method will generate a DeprecationWarning. Generally speaking, we should try to get rid of those warnings as they crop up in downstream code, by migrating that code sooner than later. When defining the ``dataset_name`` abstract class property, ``"name"`` is passed for the ``fallback`` argument. When the ``dataset_name`` property is accessed, first it will look for a concrete definition for ``dataset_name`` in the bound class. If it fails to find that, then it will fall back to looking for a ``name`` class method and use that (with a DeprecationWarning) if it finds one.

There is also a, seemingly circular, definition of the ``name`` classmethod in the ``Attributes`` mixin which uses the ``_find_fallback`` method to look for a ``dataset_name`` value. This is not for backwards compatibility with downstream code, as dataset managers that use ``name`` will also have defined ``name``, so this won't be used for those. This is here because ``gridded_etl_tools`` doesn't yet have 100% test coverage, so there is always some risk of some untested code in ``gridded_etl_tools`` using an older style class method instead of the property which has replaced it. When test coverage is up to 100%, it should be possible to remove ``_find_fallback`` and the fallback class methods that use it.