### PR TITLE
Write .zattrs and .zmetadata JSON directly to indicate update_in_progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ dask-worker-space/
 # Editor/IDE
 *.swp
 .vscode
+.flake8
+mypy.ini
 
 # Tests temp data
 tests/local_*/

--- a/gridded_etl_tools/utils/attributes.py
+++ b/gridded_etl_tools/utils/attributes.py
@@ -193,6 +193,12 @@ class Attributes(ABC):
     def temporal_resolution(cls) -> str:
         return cls._find_fallback("time_resolution")
 
+    update_attributes: list[str] = ["date range", "update_previous_end_date"]
+    """
+    Certain fields of a dataset should not be overwritten until after a parse completes to avoid confusion
+     if a parse fails midway.
+    """
+
     update_cadence: str | None = None
     """
     The frequency with which a dataset is updated.

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -85,6 +85,30 @@ class StoreInterface(ABC):
         else:
             return None
 
+    @abstractmethod
+    def write_metadata_only(self, attributes: dict):
+        """
+        Writes the metadata to the stored Zarr. Not available to datasets on the IPLD store. Use DatasetManager.to_zarr
+        instead.
+
+        Open the Zarr's `.zmetadata` and `.zattr` files with the JSON library, update the values with the values in the
+        given dict, and write the files.
+
+        These changes will be reflected in the attributes dict of subsequent calls to `DatasetManager.store.dataset`
+        without needing to call `DatasetManager.to_zarr`.
+
+        Parameters
+        ----------
+        attributes
+            A dict of metadata attributes to add or update to the Zarr
+
+        Raises
+        ------
+        NotImplementedError
+            If the store is IPLD
+        """
+        pass
+
 
 class S3(StoreInterface):
     """
@@ -280,6 +304,25 @@ class S3(StoreInterface):
         else:
             return f"s3://{self.bucket}/metadata/{title}.json"
 
+    def write_metadata_only(self, attributes: dict):
+        # Edit both .zmetadata and .zattrs
+        for z_path in (".zmetadata", ".zattrs"):
+            current_attributes = {}
+
+            # Read current metadata from Zarr
+            with self.fs().open(f"{self.path}/{z_path}") as z_contents:
+                current_attributes.update(json.load(z_contents))
+
+            # Update given attributes at the appropriate location depending on which z file
+            if z_path == ".zmetadata":
+                current_attributes["metadata"][".zattrs"].update(attributes)
+            else:
+                current_attributes.update(attributes)
+
+            # Write back to Zarr
+            with self.fs().open(f"{self.path}/{z_path}", "w") as z_contents:
+                json.dump(current_attributes, z_contents)
+
 
 class IPLD(StoreInterface):
     """
@@ -362,6 +405,9 @@ class IPLD(StoreInterface):
             Return `True` if the dataset has a latest hash, or `False` otherwise.
         """
         return bool(self.dm.latest_hash())
+
+    def write_metadata_only(self, attributes: dict):
+        raise NotImplementedError("Can't write metadata-only on the IPLD store. Use DatasetManager.to_zarr instead.")
 
 
 class Local(StoreInterface):
@@ -528,3 +574,22 @@ class Local(StoreInterface):
             The s3 path for this entity as a pathlib.Path
         """
         return (pathlib.Path() / "metadata" / stac_type / f"{title}.json").resolve()
+
+    def write_metadata_only(self, attributes: dict):
+        # Edit both .zmetadata and .zattrs
+        for z_path in (".zmetadata", ".zattrs"):
+            current_attributes = {}
+
+            # Read current metadata from Zarr
+            with open(self.path / z_path) as z_contents:
+                current_attributes.update(json.load(z_contents))
+
+            # Update given attributes at the appropriate location depending on which z file
+            if z_path == ".zmetadata":
+                current_attributes["metadata"][".zattrs"].update(attributes)
+            else:
+                current_attributes.update(attributes)
+
+            # Write back to Zarr
+            with open(self.path / z_path, "w") as z_contents:
+                json.dump(current_attributes, z_contents)

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -308,11 +308,10 @@ class S3(StoreInterface):
     def write_metadata_only(self, update_attrs: dict[str, Any]):
         # Edit both .zmetadata and .zattrs
         for z_path in (".zmetadata", ".zattrs"):
-            current_attributes = {}
 
             # Read current metadata from Zarr
             with self.fs().open(f"{self.path}/{z_path}") as z_contents:
-                current_attributes.update(json.load(z_contents))
+                current_attributes = json.load(z_contents)
 
             # Update given attributes at the appropriate location depending on which z file
             if z_path == ".zmetadata":
@@ -579,11 +578,10 @@ class Local(StoreInterface):
     def write_metadata_only(self, update_attrs: dict[str, Any]):
         # Edit both .zmetadata and .zattrs
         for z_path in (".zmetadata", ".zattrs"):
-            current_attributes = {}
 
             # Read current metadata from Zarr
             with open(self.path / z_path) as z_contents:
-                current_attributes.update(json.load(z_contents))
+                current_attributes = json.load(z_contents)
 
             # Update given attributes at the appropriate location depending on which z file
             if z_path == ".zmetadata":

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -576,7 +576,7 @@ class Local(StoreInterface):
         """
         return (pathlib.Path() / "metadata" / stac_type / f"{title}.json").resolve()
 
-    def write_metadata_only(self, attributes: dict):
+    def write_metadata_only(self, update_attrs: dict[str, Any]):
         # Edit both .zmetadata and .zattrs
         for z_path in (".zmetadata", ".zattrs"):
             current_attributes = {}
@@ -587,9 +587,9 @@ class Local(StoreInterface):
 
             # Update given attributes at the appropriate location depending on which z file
             if z_path == ".zmetadata":
-                current_attributes["metadata"][".zattrs"].update(attributes)
+                current_attributes["metadata"][".zattrs"].update(update_attrs)
             else:
-                current_attributes.update(attributes)
+                current_attributes.update(update_attrs)
 
             # Write back to Zarr
             with open(self.path / z_path, "w") as z_contents:

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -308,7 +308,6 @@ class S3(StoreInterface):
     def write_metadata_only(self, update_attrs: dict[str, Any]):
         # Edit both .zmetadata and .zattrs
         for z_path in (".zmetadata", ".zattrs"):
-
             # Read current metadata from Zarr
             with self.fs().open(f"{self.path}/{z_path}") as z_contents:
                 current_attributes = json.load(z_contents)
@@ -578,7 +577,6 @@ class Local(StoreInterface):
     def write_metadata_only(self, update_attrs: dict[str, Any]):
         # Edit both .zmetadata and .zattrs
         for z_path in (".zmetadata", ".zattrs"):
-
             # Read current metadata from Zarr
             with open(self.path / z_path) as z_contents:
                 current_attributes = json.load(z_contents)

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -18,6 +18,7 @@ import fsspec
 import collections
 
 from abc import abstractmethod, ABC
+from typing import Any
 
 
 class StoreInterface(ABC):
@@ -304,7 +305,8 @@ class S3(StoreInterface):
         else:
             return f"s3://{self.bucket}/metadata/{title}.json"
 
-    def write_metadata_only(self, attributes: dict):
+    def write_metadata_only(self, update_attrs: dict[str, Any]):
+
         # Edit both .zmetadata and .zattrs
         for z_path in (".zmetadata", ".zattrs"):
             current_attributes = {}
@@ -315,9 +317,9 @@ class S3(StoreInterface):
 
             # Update given attributes at the appropriate location depending on which z file
             if z_path == ".zmetadata":
-                current_attributes["metadata"][".zattrs"].update(attributes)
+                current_attributes["metadata"][".zattrs"].update(update_attrs)
             else:
-                current_attributes.update(attributes)
+                current_attributes.update(update_attrs)
 
             # Write back to Zarr
             with self.fs().open(f"{self.path}/{z_path}", "w") as z_contents:

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -306,7 +306,6 @@ class S3(StoreInterface):
             return f"s3://{self.bucket}/metadata/{title}.json"
 
     def write_metadata_only(self, update_attrs: dict[str, Any]):
-
         # Edit both .zmetadata and .zattrs
         for z_path in (".zmetadata", ".zattrs"):
             current_attributes = {}

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -584,7 +584,7 @@ class Publish(Transform, Metadata):
                     }
                 )
                 # Remove update attributes from the dataset putting them in a dictionary to be written post-parse
-                post_parse_attrs = self.post_parse_attrs(dataset=dataset)
+                dataset, post_parse_attrs = self.move_post_parse_attrs_to_dict(dataset=dataset)
 
             # Write data to Zarr and log duration.
             start_writing = time.perf_counter()
@@ -597,7 +597,7 @@ class Publish(Transform, Metadata):
                 self.info("Writing metadata after writing data to indicate write is finished.")
                 self.store.write_metadata_only(update_attrs=post_parse_attrs)
 
-    def post_parse_attrs(self, dataset: xr.Dataset = None) -> dict[str, Any]:
+    def post_parse_attrs(self, dataset: xr.Dataset) -> dict[str, Any]:
         """
         Build a dictionary of attributes that should only be populated to a Zarr after parsing finishes
         While building this dict, remove these attributes from the dataset to be written.
@@ -620,7 +620,7 @@ class Publish(Transform, Metadata):
                 # For example "date range" should only be updated after a successful parse
                 update_attrs[attr] = dataset.attrs.pop(attr, None)
 
-        return update_attrs
+        return dataset, update_attrs
 
     # SETUP
 

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -612,6 +612,7 @@ class Publish(Transform, Metadata):
         update_attrs
             A dictionary of [str, Any] keypairs to be written to a Zarr only after a successful parse has finished
         """
+        dataset = dataset.copy()
         update_attrs = {"update_in_progress": False}
         # Build a dictionary of attributes to update post-parse
         for attr in self.update_attributes:

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -20,7 +20,7 @@ from typing import Any
 from tqdm import tqdm
 from subprocess import Popen
 from contextlib import nullcontext
-from itertools import starmap, repeat, chain
+from itertools import starmap, repeat
 from kerchunk.hdf import SingleHdf5ToZarr
 from kerchunk.grib2 import scan_grib
 from kerchunk.combine import MultiZarrToZarr

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -613,8 +613,7 @@ class Publish(Transform, Metadata):
         # Build a dictionary of attributes to update post-parse
         for attr in self.update_attributes:
             if attr in dataset.attrs:
-                # Remove update attribute fields from the dataset so they aren't written
-                # with the dataset. 
+                # Remove update attribute fields from the dataset so they aren't written with the dataset
                 # For example "date range" should only be updated after a successful parse
                 update_attrs[attr] = dataset.attrs.pop(attr, None)
 

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -597,7 +597,7 @@ class Publish(Transform, Metadata):
                 self.info("Writing metadata after writing data to indicate write is finished.")
                 self.store.write_metadata_only(update_attrs=post_parse_attrs)
 
-    def move_post_parse_attrs_to_dict(self, dataset: xr.Dataset) -> dict[str, Any]:
+    def move_post_parse_attrs_to_dict(self, dataset: xr.Dataset) -> tuple[xr.Dataset, dict[str, Any]]:
         """
         Build a dictionary of attributes that should only be populated to a Zarr after parsing finishes
         While building this dict, remove these attributes from the dataset to be written.
@@ -609,6 +609,8 @@ class Publish(Transform, Metadata):
 
         Returns
         -------
+        dataset
+            The xr.Dataset about to be written, with `self.update_attributes` keys removed from attributes
         update_attrs
             A dictionary of [str, Any] keypairs to be written to a Zarr only after a successful parse has finished
         """

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -572,7 +572,8 @@ class Publish(Transform, Metadata):
             self.info(f"Dataset final state pre-parse:\n{dataset}")
         else:
             # Don't use update-in-progress metadata flag on IPLD or on a dataset that doesn't have existing data stored
-            if not isinstance(self.store, IPLD) and self.store.has_existing:
+            exists_at_start = self.store.has_existing
+            if not isinstance(self.store, IPLD) and exists_at_start:
                 # Update metadata on disk with new values for update_in_progress and update_is_append_only, so that if
                 # a Zarr is opened during writing, there will be indicators that show the data is being edited.
                 self.info("Writing metadata before writing data to indicate write is in progress.")
@@ -591,7 +592,7 @@ class Publish(Transform, Metadata):
             self.info(f"Writing Zarr took {datetime.timedelta(seconds=time.perf_counter() - start_writing)}")
 
             # Don't use update-in-progress metadata flag on IPLD
-            if not isinstance(self.store, IPLD):
+            if not isinstance(self.store, IPLD) and exists_at_start:
                 # Indicate in metadata that update is complete.
                 self.info("Writing metadata after writing data to indicate write is finished.")
                 self.store.write_metadata_only(update_attrs=post_parse_attrs)

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -576,10 +576,12 @@ class Publish(Transform, Metadata):
                 # Update metadata on disk with new values for update_in_progress and update_is_append_only, so that if
                 # a Zarr is opened during writing, there will be indicators that show the data is being edited.
                 self.info("Writing metadata before writing data to indicate write is in progress.")
-                self.store.write_metadata_only(update_attrs={
-                    "update_in_progress": True,
-                    "update_is_append_only": dataset.get("update_is_append_only")
-                })
+                self.store.write_metadata_only(
+                    update_attrs={
+                        "update_in_progress": True,
+                        "update_is_append_only": dataset.get("update_is_append_only"),
+                    }
+                )
                 # Remove update attributes from the dataset putting them in a dictionary to be written post-parse
                 post_parse_attrs = self.post_parse_attrs(dataset=dataset)
 
@@ -609,7 +611,7 @@ class Publish(Transform, Metadata):
         update_attrs
             A dictionary of [str, Any] keypairs to be written to a Zarr only after a successful parse has finished
         """
-        update_attrs = {"update_in_progress" : False}
+        update_attrs = {"update_in_progress": False}
         # Build a dictionary of attributes to update post-parse
         for attr in self.update_attributes:
             if attr in dataset.attrs:

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -573,14 +573,12 @@ class Publish(Transform, Metadata):
         else:
             # Don't use update-in-progress metadata flag on IPLD or on a dataset that doesn't have existing data stored
             if not isinstance(self.store, IPLD) and self.store.has_existing:
-
                 # Update metadata on disk with new values for update_in_progress and update_is_append_only, so that if
                 # a Zarr is opened during writing, there will be indicators that show the data is being edited.
                 self.info("Writing metadata before writing data to indicate write is in progress.")
-                self.store.write_metadata_only({
-                    "update_in_progress": True,
-                    "update_is_append_only": dataset.get("update_is_append_only")
-                })
+                self.store.write_metadata_only(
+                    {"update_in_progress": True, "update_is_append_only": dataset.get("update_is_append_only")}
+                )
 
             # Write data to Zarr and log duration.
             start_writing = time.perf_counter()
@@ -589,12 +587,9 @@ class Publish(Transform, Metadata):
 
             # Don't use update-in-progress metadata flag on IPLD
             if not isinstance(self.store, IPLD):
-
                 # Indicate in metadata that update is complete.
                 self.info("Writing metadata after writing data to indicate write is finished.")
-                self.store.write_metadata_only({
-                    "update_in_progress": False
-                })
+                self.store.write_metadata_only({"update_in_progress": False})
 
     # SETUP
 

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -597,7 +597,7 @@ class Publish(Transform, Metadata):
                 self.info("Writing metadata after writing data to indicate write is finished.")
                 self.store.write_metadata_only(update_attrs=post_parse_attrs)
 
-    def post_parse_attrs(self, dataset: xr.Dataset) -> dict[str, Any]:
+    def move_post_parse_attrs_to_dict(self, dataset: xr.Dataset) -> dict[str, Any]:
         """
         Build a dictionary of attributes that should only be populated to a Zarr after parsing finishes
         While building this dict, remove these attributes from the dataset to be written.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,5 +91,5 @@ namespaces = false
 
 [tool.flake8]
 # flake8 and black disagree on E203 and W503
-ignore = "E203 W503"
+ignore = ["E203", "W503"]
 max-line-length = 119

--- a/tests/unit/test_zarr_methods.py
+++ b/tests/unit/test_zarr_methods.py
@@ -113,9 +113,8 @@ def test_calculate_update_time_ranges(
     append_size = (append_update[-1] - append_update[0]).astype("timedelta64[D]")
     assert append_size == np.timedelta64(35, "D")
 
-def test_to_zarr(mocker,
-                 manager_class: DatasetManager,
-                 fake_original_dataset: xr.Dataset):
+
+def test_to_zarr(mocker, manager_class: DatasetManager, fake_original_dataset: xr.Dataset):
     """
     Test that calls to `to_zarr` correctly run three times,
      updating relevant metadata fields to show a parse is underway.

--- a/tests/unit/test_zarr_methods.py
+++ b/tests/unit/test_zarr_methods.py
@@ -1,16 +1,26 @@
 import os
 import json
+import pytest
 
 import numpy as np
 import xarray as xr
 
 from unittest.mock import Mock
 from copy import deepcopy
-from xarray.testing import assert_identical
 
 from gridded_etl_tools.dataset_manager import DatasetManager
-from gridded_etl_tools.utils import store
-from ..common import get_manager
+from ..common import get_manager, mock_output_root, remove_mock_output
+
+
+@pytest.fixture(scope="function")
+def setup_and_teardown():
+    """
+    Call the setup functions first, in a chain ending with `simulate_file_download`.
+    Next run the test in question. Finally, remove generated inputs afterwards, even if the test fails.
+    """
+    yield  # run the tests first
+    # delete temp files
+    remove_mock_output()
 
 
 def test_standard_dims(mocker, manager_class: DatasetManager):
@@ -114,7 +124,7 @@ def test_calculate_update_time_ranges(
     assert append_size == np.timedelta64(35, "D")
 
 
-def test_to_zarr(mocker, manager_class: DatasetManager, fake_original_dataset: xr.Dataset):
+def test_to_zarr(mocker, manager_class: DatasetManager, fake_original_dataset: xr.Dataset, setup_and_teardown):
     """
     Test that calls to `to_zarr` correctly run three times,
      updating relevant metadata fields to show a parse is underway.
@@ -123,58 +133,51 @@ def test_to_zarr(mocker, manager_class: DatasetManager, fake_original_dataset: x
      *after* a successful parse
     """
     dm = manager_class()
-    dm.set_key_dims()
     dm.update_attributes = ["date range", "update_previous_end_date", "another attribute"]
-    update_dict = {
-        "date range": ("2000010100", "2021010523"),
+    pre_update_dict = {
+        "date range": ["2000010100", "2020123123"],
+        "update_date_range": ["202012293", "2020123123"],
+        "update_previous_end_date": "2020123023",
+        "update_in_progress": False,
+        "attribute relevant to updates": 1,
+        "another attribute": True,
+    }
+    post_update_dict = {
+        "date range": ["2000010100", "2021010523"],
         "update_previous_end_date": "2020123123",
         "update_in_progress": False,
         "another attribute": True,
     }
     # Mock datasets
     dataset = deepcopy(fake_original_dataset)
-    dataset.attrs.update(
-        **{
-            "date range": ("2000010100", "2020123123"),
-            "update_date_range": ("202012293", "2020123123"),
-            "update_previous_end_date": "2020123023",
-            "update_in_progress": False,
-            "attribute relevant to updates": 1,
-            "another attribute": True,
-        }
-    )
-    update_dataset = deepcopy(fake_original_dataset)
-    update_dataset.attrs.update(
-        **{
-            "date range": ("2000010100", "2021010523"),
-            "update_date_range": ("2021010123", "2021010523"),
-            "update_previous_end_date": "2020123123",
-            "another attribute": True,
-        }
-    )
-    empty_dataset_pre_update = deepcopy(update_dataset)
-    empty_dataset_pre_update.attrs = {
-        "update_in_progress": True,
-        "update_date_range": ("202012293", "2020123123"),
-        "another_attribute": True,
-    }
-    empty_dataset_pre_update = empty_dataset_pre_update.drop(["latitude", "longitude", "time", "data"])
-    empty_dataset_post_update = deepcopy(empty_dataset_pre_update)
-    empty_dataset_post_update.attrs.update({"update_in_progress": False})
+    dataset.attrs.update(**pre_update_dict)
+    dm.custom_output_path = mock_output_root / "to_zarr_dataset.zarr/"
+    dataset.to_zarr(dm.custom_output_path)  # write out local file to test updates on
     # Mock functions
-    xr.core.dataset.Dataset.to_zarr = Mock(autospec=True, return_value=None)
     dm.pre_parse_quality_check = Mock()
-    dm.store = Mock(
-        has_existing=True,
-        mapper=Mock(refresh=True, return_value=None),
-        dataset=Mock(return_value=dataset),
-        spec=store.Local,
-    )
-    # And finally, test the function works as it should
-    dm.to_zarr(update_dataset, dm.store.mapper, append_dim=dm.time_dim)
+    # Tests
+    for key in pre_update_dict.keys():
+        assert dm.store.dataset().attrs[key] == pre_update_dict[key]
+
+    dataset.attrs.update(**post_update_dict)
+    dm.to_zarr(dataset, dm.store.mapper(), append_dim=dm.time_dim)
+
+    for key in post_update_dict.keys():
+        assert dm.store.dataset().attrs[key] == post_update_dict[key]
 
     dm.pre_parse_quality_check.assert_called_once_with(dataset)
-    assert xr.core.dataset.Dataset.to_zarr.call_count == 3
-    assert_identical(dm.define_pre_update_ds(dataset)[0], empty_dataset_pre_update)
-    assert_identical(xr.core.dataset.Dataset.to_zarr.call_args_list[1][0][0], update_dataset)
-    assert_identical(dm.define_post_update_ds(empty_dataset_pre_update, update_dict), empty_dataset_post_update)
+
+
+def test_post_parse_attrs(manager_class: DatasetManager, fake_original_dataset: xr.Dataset):
+    dm = manager_class()
+    dm.update_attributes = ["date range", "update_previous_end_date", "another attribute"]
+    post_update_dict = {
+        "date range": ["2000010100", "2021010523"],
+        "update_previous_end_date": "2020123123",
+        "another attribute": True,
+        "update_in_progress": False,
+    }
+    # Mock datasets
+    dataset = fake_original_dataset
+    dataset.attrs.update(**post_update_dict)
+    assert dm.post_parse_attrs(dataset) == post_update_dict

--- a/tests/unit/test_zarr_methods.py
+++ b/tests/unit/test_zarr_methods.py
@@ -180,4 +180,4 @@ def test_post_parse_attrs(manager_class: DatasetManager, fake_original_dataset: 
     # Mock datasets
     dataset = fake_original_dataset
     dataset.attrs.update(**post_update_dict)
-    assert dm.move_post_parse_attrs_to_dict(dataset) == post_update_dict
+    assert dm.move_post_parse_attrs_to_dict(dataset)[1] == post_update_dict

--- a/tests/unit/test_zarr_methods.py
+++ b/tests/unit/test_zarr_methods.py
@@ -180,4 +180,4 @@ def test_post_parse_attrs(manager_class: DatasetManager, fake_original_dataset: 
     # Mock datasets
     dataset = fake_original_dataset
     dataset.attrs.update(**post_update_dict)
-    assert dm.post_parse_attrs(dataset) == post_update_dict
+    assert dm.move_post_parse_attrs_to_dict(dataset) == post_update_dict


### PR DESCRIPTION
This removes the empty_dataset metadata-only write hack in favor of directly writing the .zattrs and .zmetadata JSON to do a metadata-only write.

This is working in tests with S3 and local. Before to_zarr, update_in_progress is True in the dataset attrs in xarray (checked by calling DM.store.dataset), and after to_zarr update_in_progress is False.