### PR TITLE
Kerchunk file filter

### DIFF
--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -81,9 +81,7 @@ class Transform(Convenience):
                 # Further filter down which files are processsed using an optional file filter string or integer
                 if file_filters:
                     input_files_list = [
-                        fil
-                        for fil in input_files_list
-                        if any(str_filter for str_filter in file_filters if str_filter in fil)
+                        fil for fil in input_files_list if any(file_filter in fil for file_filter in file_filters)
                     ]
                 # Now prepare the MultiZarr
                 self.info(

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -39,7 +39,7 @@ class Transform(Convenience):
     # KERCHUNKING
 
     def create_zarr_json(
-        self, force_overwrite: bool = True, file_filter: str | None = None, outfile_path: str | None = None
+        self, force_overwrite: bool = True, file_filter: list[str] | None = None, outfile_path: str | None = None
     ):
         """
         Convert list of local input files (MultiZarr) to a single JSON representing a "virtual" Zarr
@@ -57,7 +57,7 @@ class Transform(Convenience):
             Switch to use (or not) an existing MultiZarr JSON at `DatasetManager.zarr_json_path()`.
             Defaults to ovewriting any existing JSON under the assumption new data has been found.
         file_filter
-            A string used to further filter down input files for kerchunkifying.
+            A list of strings used to further filter down input files for kerchunkifying.
             Useful if you want to kerchunkify only a subset of available files.
             Defaults to None.
         outfile_path
@@ -80,7 +80,7 @@ class Transform(Convenience):
                 ]
                 # Further filter down which files are processsed using an optional file filter string or integer
                 if file_filter:
-                    input_files_list = [fil for fil in input_files_list if file_filter in str(fil)]
+                    input_files_list = [fil for fil in input_files_list if str(fil) in file_filter]
                 # Now prepare the MultiZarr
                 self.info(
                     f"Generating Zarr JSON for {len(input_files_list)} files with {multiprocessing.cpu_count()} "

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -104,9 +104,6 @@ class Transform(Convenience):
             # misspecified.
             if not outfile_path:
                 outfile_path = self.zarr_json_path()
-            import ipdb
-
-            ipdb.set_trace(context=4)
             mzz.translate(filename=outfile_path)
             self.info(f"Kerchunking to Zarr JSON --- {round((time.time() - start_kerchunking)/60,2)} minutes")
         else:

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -39,7 +39,7 @@ class Transform(Convenience):
     # KERCHUNKING
 
     def create_zarr_json(
-        self, force_overwrite: bool = True, file_filter: list[str] | None = None, outfile_path: str | None = None
+        self, force_overwrite: bool = True, file_filters: list[str] | None = None, outfile_path: str | None = None
     ):
         """
         Convert list of local input files (MultiZarr) to a single JSON representing a "virtual" Zarr
@@ -56,7 +56,7 @@ class Transform(Convenience):
         force_overwrite : bool, optional
             Switch to use (or not) an existing MultiZarr JSON at `DatasetManager.zarr_json_path()`.
             Defaults to ovewriting any existing JSON under the assumption new data has been found.
-        file_filter
+        file_filters
             A list of strings used to further filter down input files for kerchunkifying.
             Useful if you want to kerchunkify only a subset of available files.
             Defaults to None.
@@ -79,8 +79,12 @@ class Transform(Convenience):
                     )
                 ]
                 # Further filter down which files are processsed using an optional file filter string or integer
-                if file_filter:
-                    input_files_list = [fil for fil in input_files_list if str(fil) in file_filter]
+                if file_filters:
+                    input_files_list = [
+                        fil
+                        for fil in input_files_list
+                        if any(str_filter for str_filter in file_filters if str_filter in fil)
+                    ]
                 # Now prepare the MultiZarr
                 self.info(
                     f"Generating Zarr JSON for {len(input_files_list)} files with {multiprocessing.cpu_count()} "
@@ -102,6 +106,9 @@ class Transform(Convenience):
             # misspecified.
             if not outfile_path:
                 outfile_path = self.zarr_json_path()
+            import ipdb
+
+            ipdb.set_trace(context=4)
             mzz.translate(filename=outfile_path)
             self.info(f"Kerchunking to Zarr JSON --- {round((time.time() - start_kerchunking)/60,2)} minutes")
         else:

--- a/tests/unit/utils/test_zarr_methods.py
+++ b/tests/unit/utils/test_zarr_methods.py
@@ -61,11 +61,11 @@ class TestTransform:
         md = manager_class()
         md._root_directory = tmp_path
 
-        md.create_zarr_json(file_filter="three")
+        md.create_zarr_json(file_filters=["three", "five"])
 
         mzz.assert_called_once_with(
-            path=[str(list(input_files.keys())[2])],
-            indicts=[list(input_files.values())[2]],
+            path=[str(list(input_files.keys())[i]) for i in [2, 4]],
+            indicts=[list(input_files.values())[i] for i in [2, 4]],
             remote_protocol="handshake",
             remote_options={"anon": True},
             identical_dims=["x", "y"],


### PR DESCRIPTION
The `file_filter` option for Kerchunk currently only accepts a single string. This PR allows a list of strings to be passed for more expansive and nuanced filtering.