### PR TITLE
add postprocess_kerchunk method

### DIFF
--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -11,10 +11,12 @@ import glob
 import os
 import random
 import s3fs
+import zarr
 
 from contextlib import nullcontext
 from subprocess import Popen
-from typing import Any
+from typing import Any, Union
+from collections.abc import MutableMapping
 
 import pandas as pd
 import numpy as np
@@ -319,6 +321,7 @@ class Transform(Convenience):
             identical_dims=cls.identical_dimensions,
             concat_dims=cls.concat_dimensions,
             preprocess=cls.preprocess_kerchunk,
+            postprocess=cls.postprocess_kerchunk,
         )
         return opts
 
@@ -353,6 +356,29 @@ class Transform(Convenience):
             fill_value_fix["fill_value"] = cls.missing_value
             refs[f"{ref}/.zarray"] = json.dumps(fill_value_fix)
         return refs
+
+    @classmethod
+    def postprocess_kerchunk(
+        cls, out_zarr: Union[zarr._storage.store.BaseStore, MutableMapping]
+    ) -> Union[zarr._storage.store.BaseStore, MutableMapping]:
+        """
+        Class method to modify the in-memory Zarr created by Kerchunk for each file
+        using Zarr methods. Useful where manipulating individual files via the reference dictionary in
+        'preprocess_kerchunk' is either clumsy or impossible.
+
+        Meant to be inherited and manipulated by child dataset managers as appropriate
+
+        Parameters
+        ----------
+        out_zarr
+            The Zarr returned by a kerchunk read of an individual Kerchunk JSON
+
+        Returns
+        -------
+        out_zarr
+            A modified version of the Zarr returned by a kerchunk read of an individual Kerchunk JSON
+        """
+        return out_zarr
 
     # CONVERT FILES
 

--- a/tests/unit/utils/test_zarr_methods.py
+++ b/tests/unit/utils/test_zarr_methods.py
@@ -56,6 +56,7 @@ class TestTransform:
             identical_dims=["x", "y"],
             concat_dims=["z", "zz"],
             preprocess=md.preprocess_kerchunk,
+            postprocess=md.postprocess_kerchunk,
         )
 
         outfile = tmp_path / "datasets" / "merged_zarr_jsons" / "DummyManager_zarr.json"
@@ -77,6 +78,7 @@ class TestTransform:
             identical_dims=["x", "y"],
             concat_dims=["z", "zz"],
             preprocess=md.preprocess_kerchunk,
+            postprocess=md.postprocess_kerchunk,
         )
 
         outfile = tmp_path / "datasets" / "merged_zarr_jsons" / "DummyManager_zarr.json"
@@ -98,6 +100,7 @@ class TestTransform:
             identical_dims=["x", "y"],
             concat_dims=["z", "zz"],
             preprocess=md.preprocess_kerchunk,
+            postprocess=md.postprocess_kerchunk,
         )
 
         outfile = tmp_path / "datasets" / "merged_zarr_jsons" / "DummyManager_zarr.json"
@@ -119,6 +122,7 @@ class TestTransform:
             identical_dims=["x", "y"],
             concat_dims=["z", "zz"],
             preprocess=md.preprocess_kerchunk,
+            postprocess=md.postprocess_kerchunk,
         )
 
         mzz.return_value.translate.assert_called_once_with(filename="put/it/here")
@@ -158,6 +162,7 @@ class TestTransform:
             identical_dims=["x", "y"],
             concat_dims=["z", "zz"],
             preprocess=md.preprocess_kerchunk,
+            postprocess=md.postprocess_kerchunk,
         )
 
         outfile = tmp_path / "datasets" / "merged_zarr_jsons" / "DummyManager_zarr.json"


### PR DESCRIPTION
Sometimes individual files need to be modified before being combined into a MultiZarr. Modifying the refs dict created by Kerchunk does not handle every case or is very unwieldy. This allows for manipulation of the in-memory Zarr created by Kerchunk.