### PR TITLE
tests: fix qc system test

### DIFF
--- a/tests/system/test_post_parse_qc.py
+++ b/tests/system/test_post_parse_qc.py
@@ -163,7 +163,6 @@ def test_get_original_ds(mocker, manager_class, initial_input_path, appended_inp
     dm.original_files = nc4_input_files(dm)
     assert dm.get_original_ds(random_coords)
     # Remote data
-    dm.protocol = "s3"
     dm.input_files = Mock(return_value=json_input_files(dm))
     assert dm.get_original_ds(random_coords)
 


### PR DESCRIPTION
After a great deal of spelunking in library code like Kerchunk and Xarray, I was trying to write an isolated test case for reporting a potential bug in Xarray. I noticed that we were passing "remote_prototocol": "s3" in the backend storage options of the call to xarray.open_dataset, and figured I should at least try it without that, and it turns out that fixes it.

Given everything else I've looked at and discussed over in Slack, I can't tell you exactly why this fixes it, but it is at least intuitive that we aren't actually using "s3" for this test so telling the backend we are could lead to problems. I'm not 100% clear on why the protocol was getting set to "s3" at this point in the test, though, so I may be missing something in the bigger picture.