### PR TITLE
chore: squash warnings

### DIFF
--- a/examples/managers/chirps.py
+++ b/examples/managers/chirps.py
@@ -80,10 +80,7 @@ class CHIRPS(DatasetManager):
 
         return static_metadata
 
-    @classmethod
-    def host_organization(cls) -> str:
-        return "My Organization"
-
+    organization = "My Organization"
     dataset_name = "chirps"
 
     def relative_path(self) -> str:

--- a/gridded_etl_tools/__init__.py
+++ b/gridded_etl_tools/__init__.py
@@ -1,6 +1,0 @@
-from pkg_resources import get_distribution, DistributionNotFound
-
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma NO COVER
-    pass  # package is not installed

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -593,7 +593,7 @@ class Local(StoreInterface):
         if self.dm.custom_output_path:
             return self.dm.custom_output_path
         else:
-            return self.dm.output_path().joinpath(f"{self.dm.name()}.zarr")
+            return self.dm.output_path().joinpath(f"{self.dm.dataset_name}.zarr")
 
     @property
     def has_existing(self) -> bool:

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -1234,7 +1234,7 @@ class Publish(Transform, Metadata):
         if len(dataset.coords) == 1:
             orig_coords = {
                 coord: self.pre_chunk_dataset.coords[coord].values
-                for coord in self.pre_chunk_dataset.drop(self.time_dim).coords
+                for coord in self.pre_chunk_dataset.drop_vars(self.time_dim).coords
             }
             dataset = dataset.assign_coords(**orig_coords)
         for random_coords in itertools.islice(shuffled_coords(dataset), checks):
@@ -1245,8 +1245,8 @@ class Publish(Transform, Metadata):
             # Check extreme values if they are defined
             if not np.isnan(random_val):
                 unit = dataset[self.data_var()].encoding["units"]
-                if unit in self.extreme_values_by_unit.keys():
-                    limit_vals = self.extreme_values_by_unit[unit]
+                if unit in self.EXTREME_VALUES_BY_UNIT.keys():
+                    limit_vals = self.EXTREME_VALUES_BY_UNIT[unit]
                     if not limit_vals[0] <= random_val <= limit_vals[1]:
                         raise ValueError(
                             f"Value {random_val} falls outside acceptable range "

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
-log_level=INFO
+log_level=WARN
+filterwarnings =
+    ; ignore warnings from other packages
+    ignore
+    ; treat warnings from our package as errors
+    error:::gridded_etl_tools.*

--- a/tests/system/test_post_parse_qc.py
+++ b/tests/system/test_post_parse_qc.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pytest
 import shutil
@@ -120,6 +121,7 @@ def test_post_parse_quality_check(mocker, manager_class, caplog, initial_input_p
     Test that the post-parse quality check method waves through good data
     and fails as anticipated with bad data
     """
+    caplog.set_level(logging.INFO)
     # Prepare a dataset manager
     dm = run_etl(manager_class, input_path=initial_input_path)
     # Approves aligned values

--- a/tests/unit/utils/test_store.py
+++ b/tests/unit/utils/test_store.py
@@ -467,13 +467,12 @@ class TestLocal:
         dm = mock.Mock(
             output_path=mock.Mock(return_value=pathlib.PosixPath("hi/mom")),
             custom_output_path=None,
+            dataset_name="Jeremy",
         )
-        dm.name = mock.Mock(return_value="Jeremy")
         store = store_module.Local(dm)
         assert store.path == pathlib.PosixPath("hi/mom/Jeremy.zarr")
 
         dm.output_path.assert_called_once_with()
-        dm.name.assert_called_once_with()
 
     @staticmethod
     def test_path_custom():


### PR DESCRIPTION
Fix all warnings originating in our code. Update pytest config to treat warnings originating in our code as errors to help us stay on top of deprecated APIs and other such things.