### PR TITLE
chore: make system test failure output more manageable

### DIFF
--- a/examples/managers/chirps.py
+++ b/examples/managers/chirps.py
@@ -352,6 +352,7 @@ class CHIRPSFinal25(CHIRPSFinal):
             requested_ipfs_chunker="size-6400",
         )
         kwargs.update(chunks)
+        kwargs["console_log"] = False
         super().__init__(*args, **kwargs)
 
     dataset_name = f"{CHIRPSFinal.dataset_name}_25"

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
-log_level=WARN
+addopts = --tb=native
+log_level = WARN
 filterwarnings =
     ; ignore warnings from other packages
     ignore


### PR DESCRIPTION
Without this, the output from some system test failures is so verbose it overruns the terminal buffer.