### PR TITLE
allow optional open_dataset_kwargs to be passed for use in raw_file_to_dataset

### DIFF
--- a/gridded_etl_tools/utils/attributes.py
+++ b/gridded_etl_tools/utils/attributes.py
@@ -262,6 +262,10 @@ class Attributes(ABC):
     Default value set as False
     """
 
+    open_dataset_kwargs = {}
+    """Some dataset types (e.g. HDF5) need special kwargs to open in Xarray. This will pass them automatically
+    during post-parse QC so these datasets can be checked automatically without issue"""
+
     @classmethod
     @deprecation.deprecated("Use the update_cadence_bounds attribute")
     def irregular_update_cadence(cls) -> None | tuple[np.timedelta64, np.timedelta64]:

--- a/gridded_etl_tools/utils/zarr_methods.py
+++ b/gridded_etl_tools/utils/zarr_methods.py
@@ -1581,7 +1581,7 @@ class Publish(Transform, Metadata):
             A file path
         """
         if self.protocol == "file":
-            return xr.open_dataset(file_path)
+            return xr.open_dataset(file_path, **self.open_dataset_kwargs)
 
         # Presumes that use_local_zarr_jsons is enabled. This avoids repeating the DL from S#
         elif self.protocol == "s3":

--- a/tests/unit/utils/test_attributes.py
+++ b/tests/unit/utils/test_attributes.py
@@ -158,6 +158,10 @@ class TestAttributes:
             assert manager_class.irregular_update_cadence() is None
 
     @staticmethod
+    def test_open_dataset_kwargs(manager_class):
+        assert manager_class.open_dataset_kwargs == {}
+
+    @staticmethod
     def test_store_with_correct_type(manager_class):
         dm = manager_class()
         local_store = store.Local(dm)


### PR DESCRIPTION
This will allow for greater flexibility when opening datasets during post parse quality checks