### PR TITLE
Add directory option to HTTP extract

### DIFF
--- a/gridded_etl_tools/utils/convenience.py
+++ b/gridded_etl_tools/utils/convenience.py
@@ -1,8 +1,5 @@
-import os
 import pathlib
 import datetime
-import re
-import ftplib
 import io
 import json
 import random
@@ -115,7 +112,7 @@ class Convenience(Attributes):
             Files from `self.local_input_path()`
 
         """
-        root = pathlib.Path(self.local_input_path)
+        root = pathlib.Path(self.local_input_path())
         for entry in natsort.natsorted(pathlib.Path(root).iterdir()):
             if not entry.name.startswith(".") and not entry.name.endswith(".idx") and entry.is_file():
                 yield pathlib.Path(root / entry.name)

--- a/gridded_etl_tools/utils/convenience.py
+++ b/gridded_etl_tools/utils/convenience.py
@@ -6,7 +6,7 @@ import ftplib
 import io
 import json
 import random
-from typing import Any
+from typing import Any, Iterator
 
 from dateutil.parser import parse as parse_date
 import deprecation
@@ -105,17 +105,17 @@ class Convenience(Attributes):
         """
         return pathlib.Path(".")
 
-    def input_files(self) -> list[pathlib.Path]:
+    def input_files(self) -> Iterator[pathlib.Path]:
         """
-        Iterator for iterating through the list of local input files
+        Iterate over the listing of local input files
 
         Returns
         -------
-        list
-            List of input files from `self.local_input_path()`
+        Generator[pathlib.Path]
+            Files from `self.local_input_path()`
 
         """
-        root = pathlib.Path(self.local_input_path())
+        root = pathlib.Path(self.local_input_path)
         for entry in natsort.natsorted(pathlib.Path(root).iterdir()):
             if not entry.name.startswith(".") and not entry.name.endswith(".idx") and entry.is_file():
                 yield pathlib.Path(root / entry.name)
@@ -438,78 +438,6 @@ class Convenience(Attributes):
                 "programmatically. Please locate the date manually."
             )
         return (self.next_date, self.next_date)
-
-    # FTP
-
-    def sync_ftp_files(
-        self,
-        server: str,
-        directory_path: str,
-        file_match_pattern: str,
-        include_size_check: bool = False,
-    ):
-        """
-        Connect to `server` (currently only supports anonymous login), change to `directory_path`, pull new and updated
-        files that match `file_match_pattern` in that directory into `self.local_input_path()`. Store a list of newly
-        downloaded files in a member variable.
-
-        Parameters
-        ----------
-        server : str
-            The URL of the FTP server to check
-        directory_path: str
-            The path to the directory holding the desired FTP files on the server
-        file_match_pattern : str
-            A regex string to match file names (in directory_path) against
-        include_size_check : bool, optional
-            Switch to check (or not) the size of files against a maximum. Defaults to False.
-
-        """
-        # Login to remote FTP server
-        with ftplib.FTP(server) as ftp:
-            self.info("checking {}:{} for files that match {}".format(server, directory_path, file_match_pattern))
-            ftp.login()
-            ftp.cwd(directory_path)
-            # Loop through directory listing
-            for file_name in ftp.nlst():
-                if re.match(file_match_pattern, file_name):
-                    # path on our local filesystem
-                    local_file_path = pathlib.Path(self.local_input_path()) / file_name
-                    modification_timestamp = ftp.sendcmd("MDTM {}".format(file_name))[4:].strip()
-                    modification_time = datetime.datetime.strptime(modification_timestamp, "%Y%m%d%H%M%S")
-                    # Retrieve this file unless we find conditions not to
-                    retrieve = True
-                    # Compare to local file of same name
-                    if local_file_path.exists():
-                        local_file_attributes = os.stat(local_file_path)
-                        local_file_mtime = datetime.datetime.fromtimestamp(local_file_attributes.st_mtime)
-                        local_file_size = local_file_attributes.st_size
-                        # Set to binary transfer mode
-                        ftp.sendcmd("TYPE I")
-                        remote_file_size = ftp.size(file_name)
-                        if modification_time <= local_file_mtime and (
-                            not include_size_check or remote_file_size == local_file_size
-                        ):
-                            self.debug("local file {} does not need updating".format(local_file_path))
-                            retrieve = False
-                        elif modification_time > local_file_mtime:
-                            self.debug(
-                                "file {} local modification time {} less than remote modification time {}".format(
-                                    local_file_path,
-                                    local_file_mtime.strftime("%Y/%m/%d"),
-                                    modification_time.strftime("%Y/%m/%d"),
-                                )
-                            )
-                        else:
-                            self.debug("mismatch between local and remote size for file {}".format(local_file_path))
-                    else:
-                        self.debug("new remote file found {}".format(file_name))
-                    # Write this file locally
-                    if retrieve:
-                        self.new_files.append(self.local_input_path() / file_name)
-                        self.info("downloading remote file {} to {}".format(file_name, local_file_path))
-                        with open(local_file_path, "wb") as fp:
-                            ftp.retrbinary("RETR {}".format(file_name), fp.write)
 
     # ETC
 

--- a/gridded_etl_tools/utils/extractor.py
+++ b/gridded_etl_tools/utils/extractor.py
@@ -31,7 +31,6 @@ log = logging.getLogger("extraction_logs")
 
 
 class Extractor(ABC):
-
     def __init__(self, dm: dataset_manager.DatasetManager, concurrency_limit: int = 8):
         """
         Create an instance of `Extrator`. `Extractor` is an abstract base class, so this should not be called directly.
@@ -292,7 +291,6 @@ class HTTPExtractor(Extractor):
 
         # Build a dynamic path if a full destination path hasn't been given
         if destination_path is None or destination_path.is_dir():
-
             # Extract the file name from the end of the URL
             file_name = pathlib.Path(os.path.basename(urlparse(remote_file_path).path))
 

--- a/tests/unit/utils/test_convenience.py
+++ b/tests/unit/utils/test_convenience.py
@@ -45,9 +45,6 @@ class DummyFtpClient:
         filename = command[5:]
         write(self.files[filename]["contents"])
 
-    def size(self, filename):
-        return len(self.files[filename]["contents"])
-
     def pwd(self):
         if self.contexts == 0:
             raise ftplib.error_perm

--- a/tests/unit/utils/test_convenience.py
+++ b/tests/unit/utils/test_convenience.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import os
 import pathlib
 import ftplib
 from unittest.mock import Mock
@@ -39,12 +38,6 @@ class DummyFtpClient:
 
     def nlst(self, *args):
         return ["one.txt", "two.dat", "three.dat"]
-
-    def sendcmd(self, command):
-        self.commands.append(command)
-        if command.startswith("MDTM "):
-            filename = command[5:]
-            return "XXX " + self.files[filename]["timestamp"]
 
     def retrbinary(self, command, write):
         self.commands.append(command)
@@ -389,116 +382,6 @@ class TestConvenience:
 
         with pytest.raises(ValueError):
             dm.get_next_date_as_date_range()
-
-    @staticmethod
-    def test_sync_ftp_files(mocker, manager_class, tmp_path):
-        ftp_client = DummyFtpClient()
-        mocker.patch("gridded_etl_tools.utils.convenience.ftplib", Mock(FTP=ftp_client))
-
-        dm = manager_class()
-        dm.custom_input_path = tmp_path
-        dm.sync_ftp_files("ftp.example.com", "/all/the/data", r".+\.dat$")
-
-        assert ftp_client.host == "ftp.example.com"
-        assert ftp_client.contexts == 0
-        ftp_client.login.assert_called_once_with()
-        ftp_client.cwd.assert_called_once_with("/all/the/data")
-        assert ftp_client.commands == [
-            "MDTM two.dat",
-            "RETR two.dat",
-            "MDTM three.dat",
-            "RETR three.dat",
-        ]
-
-        assert open(tmp_path / "two.dat").read() == "Hi Mom!"
-        assert open(tmp_path / "three.dat").read() == "Hello Dad!"
-
-    @staticmethod
-    def test_sync_ftp_files_already_downloaded(mocker, manager_class, tmp_path):
-        with open(tmp_path / "two.dat", "w") as f:
-            f.write("Hi Mom!")
-        with open(tmp_path / "three.dat", "w") as f:
-            f.write("Hello Dad!")
-        ftp_client = DummyFtpClient()
-        mocker.patch("gridded_etl_tools.utils.convenience.ftplib", Mock(FTP=ftp_client))
-
-        dm = manager_class()
-        dm.custom_input_path = tmp_path
-        dm.sync_ftp_files("ftp.example.com", "/all/the/data", r".+\.dat$")
-
-        assert ftp_client.host == "ftp.example.com"
-        assert ftp_client.contexts == 0
-        ftp_client.login.assert_called_once_with()
-        ftp_client.cwd.assert_called_once_with("/all/the/data")
-        assert ftp_client.commands == [
-            "MDTM two.dat",
-            "TYPE I",
-            "MDTM three.dat",
-            "TYPE I",
-        ]
-
-        assert open(tmp_path / "two.dat").read() == "Hi Mom!"
-        assert open(tmp_path / "three.dat").read() == "Hello Dad!"
-
-    @staticmethod
-    def test_sync_ftp_files_already_downloaded_but_wrong_size(mocker, manager_class, tmp_path):
-        with open(tmp_path / "two.dat", "w") as f:
-            f.write("Hi Mom")
-        with open(tmp_path / "three.dat", "w") as f:
-            f.write("Hello Dad")
-        ftp_client = DummyFtpClient()
-        mocker.patch("gridded_etl_tools.utils.convenience.ftplib", Mock(FTP=ftp_client))
-
-        dm = manager_class()
-        dm.custom_input_path = tmp_path
-        dm.sync_ftp_files("ftp.example.com", "/all/the/data", r".+\.dat$", include_size_check=True)
-
-        assert ftp_client.host == "ftp.example.com"
-        assert ftp_client.contexts == 0
-        ftp_client.login.assert_called_once_with()
-        ftp_client.cwd.assert_called_once_with("/all/the/data")
-        assert ftp_client.commands == [
-            "MDTM two.dat",
-            "TYPE I",
-            "RETR two.dat",
-            "MDTM three.dat",
-            "TYPE I",
-            "RETR three.dat",
-        ]
-
-        assert open(tmp_path / "two.dat").read() == "Hi Mom!"
-        assert open(tmp_path / "three.dat").read() == "Hello Dad!"
-
-    @staticmethod
-    def test_sync_ftp_files_already_downloaded_but_old(mocker, manager_class, tmp_path):
-        with open(tmp_path / "two.dat", "w") as f:
-            f.write("Hi Mom.")
-        os.utime(tmp_path / "two.dat", (0, 0))
-        with open(tmp_path / "three.dat", "w") as f:
-            f.write("Hello Dad.")
-        os.utime(tmp_path / "three.dat", (0, 0))
-        ftp_client = DummyFtpClient()
-        mocker.patch("gridded_etl_tools.utils.convenience.ftplib", Mock(FTP=ftp_client))
-
-        dm = manager_class()
-        dm.custom_input_path = tmp_path
-        dm.sync_ftp_files("ftp.example.com", "/all/the/data", r".+\.dat$", include_size_check=True)
-
-        assert ftp_client.host == "ftp.example.com"
-        assert ftp_client.contexts == 0
-        ftp_client.login.assert_called_once_with()
-        ftp_client.cwd.assert_called_once_with("/all/the/data")
-        assert ftp_client.commands == [
-            "MDTM two.dat",
-            "TYPE I",
-            "RETR two.dat",
-            "MDTM three.dat",
-            "TYPE I",
-            "RETR three.dat",
-        ]
-
-        assert open(tmp_path / "two.dat").read() == "Hi Mom!"
-        assert open(tmp_path / "three.dat").read() == "Hello Dad!"
 
     @staticmethod
     def test_bbox_coords(manager_class, fake_original_dataset):

--- a/tests/unit/utils/test_extractor.py
+++ b/tests/unit/utils/test_extractor.py
@@ -142,6 +142,12 @@ class TestHTTPExtractor:
                 os.chdir(original_working_dir)
             assert (tmp_path / "yield.html").read_bytes() == crops
 
+            # Test writing to an existing directory
+            research_folder = tmp_path / "research"
+            research_folder.mkdir(exist_ok=True)
+            extractor.request(government_website, research_folder)
+            assert (research_folder / "yield.html").read_bytes() == crops
+
     # Test that a 500 error fails with a RetryError exception
     @staticmethod
     @responses.activate

--- a/tests/unit/utils/test_extractor.py
+++ b/tests/unit/utils/test_extractor.py
@@ -20,7 +20,6 @@ class ConcreteExtractor(Extractor):
 
 
 class TestExtractor:
-
     @staticmethod
     def test_init():
         dm = Mock()
@@ -95,9 +94,7 @@ sour_avocadoes = b"\xf0\x9f\x8d\x8b\xf0\x9f\xa5\x91"
 # function and the `@responses.activate` header is used.
 @pytest.fixture
 def mocked_responses():
-
     with responses.RequestsMock() as rsps:
-
         # To test successful requests
         responses.get(government_website, body=crops, status=200)
 
@@ -113,7 +110,6 @@ def mocked_responses():
 
 
 class TestHTTPExtractor:
-
     @staticmethod
     def test_member_assignments(manager_class):
         with HTTPExtractor(manager_class(), 4, 5, 0.5) as extractor:
@@ -128,7 +124,6 @@ class TestHTTPExtractor:
     def test_requests(manager_class, mocked_responses, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         with HTTPExtractor(manager_class(), 4, 3, 0.1) as extractor:
-
             # Test writing to a given file path
             extractor.request(government_website, tmp_path / "automated_insurance.data")
             assert (tmp_path / "automated_insurance.data").read_bytes() == crops
@@ -170,9 +165,7 @@ class TestHTTPExtractor:
     @staticmethod
     @responses.activate
     def test_get_links(manager_class, mocked_responses, tmp_path):
-
         with HTTPExtractor(manager_class(), 4, 3, 0.1) as extractor:
-
             # Get all links
             links = extractor.get_links(government_website)
             assert links == set(
@@ -247,7 +240,6 @@ class TestHTTPExtractor:
 
 
 class TestS3Extractor:
-
     @staticmethod
     def test_s3_request(manager_class):
         extractor = S3Extractor(manager_class())

--- a/tests/unit/utils/test_publish.py
+++ b/tests/unit/utils/test_publish.py
@@ -17,7 +17,6 @@ from gridded_etl_tools.utils.errors import NanFrequencyMismatchError
 
 
 def generate_partial_nan_array(shape: tuple[float], percent_nan: float):
-
     # Calculate the number of NaNs and floats
     total_elements = numpy.prod(shape)
     num_nans = int(total_elements * percent_nan)
@@ -1399,7 +1398,6 @@ class TestPublish:
 
     @staticmethod
     def test_filter_search_space(manager_class, hindcast_dataset):
-
         timestamps = numpy.arange(
             numpy.datetime64("2021-10-16T00:00:00.000000000"),
             numpy.datetime64("2021-10-26T00:00:00.000000000"),
@@ -1536,7 +1534,6 @@ class TestPublish:
 
 
 class DummyDataset(UserDict):
-
     def __init__(self, *dims: tuple[tuple[str, list[float]]]):
         self.dims = tuple((dim for dim, _ in dims))
         super().__init__(((dim, mock.Mock(values=values))) for dim, values in dims)


### PR DESCRIPTION
If an existing folder is given as the destination for an HTTP request, the file will be written to the folder with the same file name it has on the remote server.

This also changes the default parameters for HTTP request retries to more reasonable defaults for a maximum 2 minute wait.