### PR TITLE
Upgrade to actions/cachev4 to avoid deprecation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -42,7 +42,7 @@ jobs:
         python-version: "3.11"
 
     - name: Cache reusable files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/pip/


### PR DESCRIPTION
Responds to upcoming deprecation of cache v2 https://github.com/actions/cache