### PR TITLE
FillValue for coords overhaul

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -36,6 +36,7 @@ def fake_original_dataset_float_coords():
     ds["data"] = ds["data"].astype("<f4")
     return ds
 
+
 @pytest.fixture
 def fake_original_dataset():
     time = xr.DataArray(np.array(original_times), dims="time", coords={"time": np.arange(138)})

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,6 +22,21 @@ def example_zarr_json():
 
 
 @pytest.fixture
+def fake_original_dataset_float_coords():
+    time = xr.DataArray(np.array(original_times), dims="time", coords={"time": np.arange(138)})
+    latitude = xr.DataArray(np.arange(1, 3, 0.5), dims="latitude", coords={"latitude": np.arange(1, 3, 0.5)})
+    longitude = xr.DataArray(np.arange(1, 3, 0.5), dims="longitude", coords={"longitude": np.arange(1, 3, 0.5)})
+    data = xr.DataArray(
+        np.random.randn(138, 4, 4),
+        dims=("time", "latitude", "longitude"),
+        coords=(time, latitude, longitude),
+    )
+
+    ds = xr.Dataset({"data": data})
+    ds["data"] = ds["data"].astype("<f4")
+    return ds
+
+@pytest.fixture
 def fake_original_dataset():
     time = xr.DataArray(np.array(original_times), dims="time", coords={"time": np.arange(138)})
     latitude = xr.DataArray(np.arange(10, 50, 10), dims="latitude", coords={"latitude": np.arange(10, 50, 10)})

--- a/tests/unit/utils/test_metadata.py
+++ b/tests/unit/utils/test_metadata.py
@@ -1037,8 +1037,16 @@ class TestMetadata:
         mv = md.missing_value
 
         assert dataset.encoding == {"data": {"dtype": "<f4", "_FillValue": mv}}
-        assert dataset.latitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
-        assert dataset.longitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
+        assert dataset.latitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
+        assert dataset.longitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
         assert dataset["data"].encoding == {
             "dtype": "<f4",
             "units": "parsecs",
@@ -1072,8 +1080,16 @@ class TestMetadata:
         mv = md.missing_value
 
         assert dataset.encoding == {"data": {"dtype": "<f4", "_FillValue": mv}}
-        assert dataset.latitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
-        assert dataset.longitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
+        assert dataset.latitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
+        assert dataset.longitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
         assert dataset["data"].encoding == {
             "dtype": "<f4",
             "units": "parsecs",
@@ -1114,8 +1130,16 @@ class TestMetadata:
         mv = md.missing_value
 
         assert dataset.encoding == {"data": {"dtype": "<f4", "_FillValue": mv}}
-        assert dataset.latitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
-        assert dataset.longitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
+        assert dataset.latitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
+        assert dataset.longitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
         assert dataset["data"].encoding == {
             "dtype": "<f4",
             "units": "parsecs",
@@ -1184,8 +1208,16 @@ class TestMetadata:
         mv = md.missing_value
 
         assert dataset.encoding == {"data": {"dtype": "<f4", "_FillValue": mv}}
-        assert dataset.latitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
-        assert dataset.longitude.encoding == {"_FillValue": -9223372036854775808, "chunks": None, "preferred_chunks": None}
+        assert dataset.latitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
+        assert dataset.longitude.encoding == {
+            "_FillValue": -9223372036854775808,
+            "chunks": None,
+            "preferred_chunks": None,
+        }
         assert dataset["data"].encoding == {
             "dtype": "<f4",
             "units": "parsecs",
@@ -1319,23 +1351,22 @@ class TestMetadata:
         # Now we can test everything else
         assert saved_ds.latitude.encoding == {
             "chunks": (4,),
-            "preferred_chunks": {'latitude': 4},
-            'compressors': (Blosc(cname='lz4', clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
-            'dtype': np.dtype('float64'),
-            'filters': (),
-            'shards': None
+            "preferred_chunks": {"latitude": 4},
+            "compressors": (Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
+            "dtype": np.dtype("float64"),
+            "filters": (),
+            "shards": None,
         }
         assert saved_ds.longitude.encoding == {
             "chunks": (4,),
             "preferred_chunks": {"longitude": 4},
-            'compressors': (Blosc(cname='lz4', clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
-            'dtype': np.dtype('float64'),
-            'filters': (),
-            'shards': None
+            "compressors": (Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
+            "dtype": np.dtype("float64"),
+            "filters": (),
+            "shards": None,
         }
         assert "missing_value" not in saved_ds.longitude.encoding
         assert "missing_value" not in saved_ds.latitude.encoding
-
 
     @staticmethod
     def test_encoding_survives_to_zarr_integer_coords(manager_class, fake_original_dataset, tmp_path):
@@ -1355,25 +1386,24 @@ class TestMetadata:
         # Test full encoding -- this time the _FillValue is an implausible integer value, not NaN
         assert saved_ds.latitude.encoding == {
             "chunks": (4,),
-            "preferred_chunks": {'latitude': 4},
+            "preferred_chunks": {"latitude": 4},
             "_FillValue": -9223372036854775808,
-            'compressors': (Blosc(cname='lz4', clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
-            'dtype': np.dtype('int64'),
-            'filters': (),
-            'shards': None
+            "compressors": (Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
+            "dtype": np.dtype("int64"),
+            "filters": (),
+            "shards": None,
         }
         assert saved_ds.longitude.encoding == {
             "chunks": (4,),
             "preferred_chunks": {"longitude": 4},
             "_FillValue": -9223372036854775808,
-            'compressors': (Blosc(cname='lz4', clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
-            'dtype': np.dtype('int64'),
-            'filters': (),
-            'shards': None
+            "compressors": (Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE, blocksize=0),),
+            "dtype": np.dtype("int64"),
+            "filters": (),
+            "shards": None,
         }
         assert "missing_value" not in saved_ds.longitude.encoding
         assert "missing_value" not in saved_ds.latitude.encoding
-
 
     @staticmethod
     def test_zarr_step_dtype_conversion_issue(tmp_path):

--- a/tests/unit/utils/test_publish.py
+++ b/tests/unit/utils/test_publish.py
@@ -818,7 +818,7 @@ class TestPublish:
         assert len(dataset.time) > len(time_values)
 
         dataset = dm.prep_update_dataset(dataset, time_values)
-        dm.encode_vars(dataset)
+        dm.encode_ds(dataset)
 
         assert np.array_equal(dataset.time, time_values)
         assert dataset.chunks == {}
@@ -843,7 +843,7 @@ class TestPublish:
         assert "time" not in dataset.dims
 
         dataset = dm.prep_update_dataset(dataset, time_values)
-        dm.encode_vars(dataset)
+        dm.encode_ds(dataset)
 
         assert np.array_equal(dataset.time, time_values[:1])
         assert dataset.chunks == {}
@@ -881,7 +881,7 @@ class TestPublish:
     def test_preparse_quality_check(manager_class, fake_original_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.check_nan_frequency = mock.Mock()
         dm.store = mock.Mock(spec=store.Local, has_existing=True)
 
@@ -894,7 +894,7 @@ class TestPublish:
     def test_preparse_quality_check_short_dataset(manager_class, single_time_instant_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(single_time_instant_dataset)
+        dm.encode_ds(single_time_instant_dataset)
         dm.check_nan_frequency = mock.Mock()
         dm.store = mock.Mock(spec=store.Local, has_existing=True)
 
@@ -910,7 +910,7 @@ class TestPublish:
         dm = manager_class()
         dm.check_random_values = mock.Mock()
         dm.check_nan_frequency = mock.Mock()
-        dm.encode_vars(dataset)
+        dm.encode_ds(dataset)
 
         with pytest.raises(IndexError):
             dm.pre_parse_quality_check(dataset)
@@ -919,7 +919,7 @@ class TestPublish:
     def test_preparse_quality_check_bad_dtype(manager_class, fake_original_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.check_nan_frequency = mock.Mock()
         fake_original_dataset.data.encoding["dtype"] = "thewrongtype"
 
@@ -929,7 +929,7 @@ class TestPublish:
     def test_preparse_quality_check_nan_binomial(mocker, manager_class, fake_large_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(fake_large_dataset)
+        dm.encode_ds(fake_large_dataset)
         dm.store = mock.Mock(spec=store.Local, has_existing=True)
 
         # patch sample size to 16, size of input dataset
@@ -967,7 +967,7 @@ class TestPublish:
     def test_preparse_quality_check_nan_binomial_small_array(mocker, manager_class, fake_original_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.store = mock.Mock(spec=store.Local, has_existing=True)
 
         # patch sample size to 16, size of input dataset
@@ -980,7 +980,7 @@ class TestPublish:
     def test_preparse_quality_check_nan_binomial_no_existing(manager_class, fake_original_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.check_nan_frequency = mock.Mock()
         dm.store = mock.Mock(spec=store.Local, has_existing=False)
         dm.pre_parse_quality_check(fake_original_dataset)
@@ -992,7 +992,7 @@ class TestPublish:
     def test_preparse_quality_check_nan_binomial_skip_check(manager_class, fake_original_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.skip_pre_parse_nan_check = True
         dm.check_nan_frequency = mock.Mock()
         dm.store = mock.Mock(spec=store.Local, has_existing=True)
@@ -1006,7 +1006,7 @@ class TestPublish:
     def test_preparse_quality_check_no_frequency_attribute(mocker, manager_class, fake_original_dataset):
         dm = manager_class()
         dm.check_random_values = mock.Mock()
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.store = mock.Mock(spec=store.Local, has_existing=True)
 
         # raise AttributeError if expected_nan_frequency attribute not present
@@ -1019,7 +1019,7 @@ class TestPublish:
         dm = manager_class()
         dm.EXTREME_VALUES_BY_UNIT = {"parsecs": (-10, 10)}
         dm.pre_chunk_dataset = fake_original_dataset
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.check_random_values(fake_original_dataset)
 
     @staticmethod
@@ -1027,7 +1027,7 @@ class TestPublish:
         fake_original_dataset.data.values[:] = np.nan
         dm = manager_class()
         dm.pre_chunk_dataset = fake_original_dataset
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         with pytest.raises(ValueError):
             dm.check_random_values(fake_original_dataset)
 
@@ -1035,7 +1035,7 @@ class TestPublish:
     def test_check_random_values_nonsense_value(manager_class, fake_original_dataset):
         dm = manager_class()
         dm.pre_chunk_dataset = fake_original_dataset
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
 
         fake_original_dataset["data"].encoding["units"] = "K"
         fake_original_dataset.data.values[:] = 1_000_000  # hot
@@ -1048,7 +1048,7 @@ class TestPublish:
         dm = manager_class()
         dm.pre_chunk_dataset = fake_original_dataset
         dataset = fake_original_dataset.drop_vars(dm._standard_dims_except(dm.time_dim))
-        dm.encode_vars(dataset)
+        dm.encode_ds(dataset)
         dm.check_random_values(dataset)
 
     @staticmethod
@@ -1056,7 +1056,7 @@ class TestPublish:
         fake_original_dataset.data.values[:] = np.nan
         dm = manager_class()
         dm.pre_chunk_dataset = fake_original_dataset
-        dm.encode_vars(fake_original_dataset)
+        dm.encode_ds(fake_original_dataset)
         dm.has_nans = True
         dm.check_random_values(fake_original_dataset)
 


### PR DESCRIPTION
Enforce nonsensical FillValue encoding for time values and integer coords, NaN for all other coords