### PR TITLE
Add S3 endpoint URL parameter to DatasetManager constructor

### DIFF
--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -135,7 +135,7 @@ class DatasetManager(Logging, Publish, ABC):
         s3_bucket_name : str
             Name of the S3 bucket where this dataset's Zarrs are stored. Only used if "s3" store is used.
         s3_endpoint_url : str, optional
-            Usually set automatically, but this can be used to force a URL for the S3 server
+            Usually the S3 endpoint is set automatically. This is intended for tests that need to mock an S3 server.
         allow_overwrite : bool
             Unless this is set to `True`, inserting or overwriting data for dates before the dataset's current end date
             will fail with a warning message.

--- a/gridded_etl_tools/dataset_manager.py
+++ b/gridded_etl_tools/dataset_manager.py
@@ -85,6 +85,7 @@ class DatasetManager(Logging, Publish, ABC):
         global_log_level=logging.DEBUG,
         store=None,
         s3_bucket_name=None,
+        s3_endpoint_url: str | None = None,
         allow_overwrite=False,
         dask_dashboard_address: str = "127.0.0.1:8787",
         dask_worker_memory_target: float = 0.65,
@@ -133,6 +134,8 @@ class DatasetManager(Logging, Publish, ABC):
             or set manually.
         s3_bucket_name : str
             Name of the S3 bucket where this dataset's Zarrs are stored. Only used if "s3" store is used.
+        s3_endpoint_url : str, optional
+            Usually set automatically, but this can be used to force a URL for the S3 server
         allow_overwrite : bool
             Unless this is set to `True`, inserting or overwriting data for dates before the dataset's current end date
             will fail with a warning message.
@@ -206,7 +209,7 @@ class DatasetManager(Logging, Publish, ABC):
         if store is None or store == "local":
             self.store = Local(self)
         elif store == "s3":
-            self.store = S3(self, s3_bucket_name)
+            self.store = S3(self, s3_bucket_name, s3_endpoint_url)
         else:
             raise ValueError("Store must be one of 'local' or 's3'")
 

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -376,12 +376,9 @@ class S3(StoreInterface):
         if self.endpoint_url is not None:
             if "storage_options" in kwargs:
                 kwargs["storage_options"] = {**kwargs["storage_options"], "endpoint_url": self.endpoint_url}
-                return super().dataset(**kwargs)
-                return super().dataset(**kwargs)
             else:
                 return super().dataset(storage_options={"endpoint_url": self.endpoint_url}, **kwargs)
-        else:
-            return super().dataset(**kwargs)
+        return super().dataset(**kwargs)
 
     def __repr__(self) -> str:
         return "S3"

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -375,7 +375,8 @@ class S3(StoreInterface):
         """
         if self.endpoint_url is not None:
             if "storage_options" in kwargs:
-                kwargs["storage_options"].update({"endpoint_url": self.endpoint_url})
+                kwargs["storage_options"] = {**kwargs["storage_options"], "endpoint_url": self.endpoint_url}
+                return super().dataset(**kwargs)
                 return super().dataset(**kwargs)
             else:
                 return super().dataset(storage_options={"endpoint_url": self.endpoint_url}, **kwargs)

--- a/gridded_etl_tools/utils/store.py
+++ b/gridded_etl_tools/utils/store.py
@@ -306,6 +306,8 @@ class S3(StoreInterface):
             The dataset to be read or written.
         bucket : str
             The name of the S3 bucket to connect to (s3://[bucket])
+        endpoint_url : str, optional
+            URL to an S3 server. Usually determined automatically, but this can be used for testing.
         """
         super().__init__(dm)
         if not bucket:
@@ -356,6 +358,29 @@ class S3(StoreInterface):
             return self.dm.custom_output_path
         else:
             return f"s3://{self.bucket}/datasets/{self.dm.key()}.zarr"
+
+    def dataset(self, **kwargs) -> xr.Dataset | None:
+        """
+        Override parent so that custom endpoint_url is sent if it is set.
+
+        Parameters
+        ----------
+        **kwargs
+            Keyword arguments to forward to xr.open_zarr, for example, "refresh=True"
+
+        Returns
+        -------
+        xr.Dataset | None
+            The dataset opened in xarray or None if there is no dataset currently stored.
+        """
+        if self.endpoint_url is not None:
+            if "storage_options" in kwargs:
+                kwargs["storage_options"].update({"endpoint_url": self.endpoint_url})
+                return super().dataset(**kwargs)
+            else:
+                return super().dataset(storage_options={"endpoint_url": self.endpoint_url}, **kwargs)
+        else:
+            return super().dataset(**kwargs)
 
     def __repr__(self) -> str:
         return "S3"

--- a/tests/unit/test_dataset_manager.py
+++ b/tests/unit/test_dataset_manager.py
@@ -109,6 +109,11 @@ class TestDatasetManager:
         dm = manager_class(store="s3", s3_bucket_name="mop_water")
         assert isinstance(dm.store, dataset_manager.S3)
         assert dm.store.bucket == "mop_water"
+        assert dm.store.endpoint_url is None
+        dm = manager_class(store="s3", s3_bucket_name="mop_water", s3_endpoint_url="fbi.access")
+        assert isinstance(dm.store, dataset_manager.S3)
+        assert dm.store.bucket == "mop_water"
+        assert dm.store.endpoint_url == "fbi.access"
 
     @staticmethod
     def test_constructor_match_existing_format(manager_class, mocker):

--- a/tests/unit/utils/test_store.py
+++ b/tests/unit/utils/test_store.py
@@ -215,7 +215,7 @@ class TestS3:
 
         # Check storage_options
         store = store_module.S3(mock.Mock(), "bucket", "fbi.access")
-        dataset = store.dataset(storage_options={"anon": True})
+        store.dataset(storage_options={"anon": True})
         mock_open_zarr.assert_called_with(
             store=store.path, decode_timedelta=True, storage_options={"anon": True, "endpoint_url": "fbi.access"}
         )

--- a/tests/unit/utils/test_store.py
+++ b/tests/unit/utils/test_store.py
@@ -198,6 +198,21 @@ class TestS3:
         assert store.path == "use/this/one/instead.zarr"
 
     @staticmethod
+    def test_dataset(mocker):
+        mock_open_zarr = mocker.patch("xarray.open_zarr")
+        store = store_module.S3(mock.Mock(), "bucket")
+        mocker.patch("gridded_etl_tools.utils.store.StoreInterface.has_existing", return_value=True)
+        mocker.patch("s3fs.S3FileSystem.exists", return_value=True)
+        dataset = store.dataset()
+        mock_open_zarr.assert_called_with(store=store.path, decode_timedelta=True)
+        store = store_module.S3(mock.Mock(), "bucket", "fbi.access")
+        dataset = store.dataset()
+        mock_open_zarr.assert_called_with(
+            store=store.path,
+            decode_timedelta=True,
+            storage_options={"endpoint_url": "fbi.access"})
+
+    @staticmethod
     def test___repr__():
         dm = mock.Mock(custom_output_path=mock.MagicMock())
         store = store_module.S3(dm, "mop_bucket")

--- a/tests/unit/utils/test_store.py
+++ b/tests/unit/utils/test_store.py
@@ -203,14 +203,23 @@ class TestS3:
         store = store_module.S3(mock.Mock(), "bucket")
         mocker.patch("gridded_etl_tools.utils.store.StoreInterface.has_existing", return_value=True)
         mocker.patch("s3fs.S3FileSystem.exists", return_value=True)
-        dataset = store.dataset()
+
+        # Call dataset just to check internal calls
+        store.dataset()
         mock_open_zarr.assert_called_with(store=store.path, decode_timedelta=True)
         store = store_module.S3(mock.Mock(), "bucket", "fbi.access")
-        dataset = store.dataset()
+        store.dataset()
+        mock_open_zarr.assert_called_with(
+            store=store.path, decode_timedelta=True, storage_options={"endpoint_url": "fbi.access"}
+        )
+
+        # Check storage_options
+        store = store_module.S3(mock.Mock(), "bucket", "fbi.access")
+        dataset = store.dataset(storage_options={"anon": True})
         mock_open_zarr.assert_called_with(
             store=store.path,
             decode_timedelta=True,
-            storage_options={"endpoint_url": "fbi.access"})
+            storage_options={"anon": True, "endpoint_url": "fbi.access"})
 
     @staticmethod
     def test___repr__():

--- a/tests/unit/utils/test_store.py
+++ b/tests/unit/utils/test_store.py
@@ -217,9 +217,8 @@ class TestS3:
         store = store_module.S3(mock.Mock(), "bucket", "fbi.access")
         dataset = store.dataset(storage_options={"anon": True})
         mock_open_zarr.assert_called_with(
-            store=store.path,
-            decode_timedelta=True,
-            storage_options={"anon": True, "endpoint_url": "fbi.access"})
+            store=store.path, decode_timedelta=True, storage_options={"anon": True, "endpoint_url": "fbi.access"}
+        )
 
     @staticmethod
     def test___repr__():


### PR DESCRIPTION
The endpoint is forwarded to the S3 Store object. This allows test programs to use the mock S3 server without mocking the Store class.

The endpoint is forwarded to xarray.open_zarr when Store.dataset is called.

This is a prerequisite for the S3 mock tests PR in gridded-etl-managers. https://github.com/Arbol-Project/gridded-etl-managers/pull/426